### PR TITLE
chore: Issueテンプレートを独自のものに変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,46 +1,32 @@
-name: 🐞 Compiler Bug Report
-description: For bugs of the Typst compiler
-title: Write a short and descriptive title!
+name: 🐛 誤字・脱字・誤訳の報告や翻訳改善の提案
+description: 誤字・脱字・誤訳の報告や翻訳改善を提案するIssueを作成します。
 labels:
   - bug
 body:
   - type: markdown
     attributes:
-      value: Thanks for reporting a bug on the Typst compiler. Did you [take a look](https://github.com/typst/typst/issues?q=is%3Aopen+is%3Aissue+label%3Abug+-label%3A%22web+app%22) if your issue has already been filed? If so, join the discussion there! Is your issue related to Typst's web app? Please file it [here](https://github.com/typst/webapp-issues/issues) instead.
+      value: 翻訳ドキュメントの改善をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/typst-jp.github.io/issues?q=is%3Aopen)
   - type: textarea
-    id: description
     attributes:
-      label: Description
-      description: Please describe your issue. Include specific steps to reproduce it or a screenshot if the problem is with Typst's output.
-      placeholder: Terse and specific description of the bug. You can add a screenshot by dragging an image here.
+      label: 対象ドキュメント
+      description: 翻訳対象のドキュメントを記載してください。
     validations:
       required: true
-  - type: input
-    id: repro-url
+  - type: textarea
     attributes:
-      label: Reproduction URL
-      description: If your did not specify Typst code above, you can share a link to your typst.app project here
-      placeholder: https://typst.app/project/rU6j4Q5foiCcvB7Hz_gs9m
+      label: 問題
+      description: 現在発生している問題やその背景を記載してください。
     validations:
-      required: false
-  - type: dropdown
-    id: os
+      required: true
+  - type: textarea
     attributes:
-      label: Operating system
-      description: Which platform did you run the compiler on?
-      multiple: true
-      options:
-        - Web app
-        - Windows
-        - Linux
-        - macOS
+      label: 改善案
+      description: 改善案を記載してください。
     validations:
-      required: false
+      required: true
   - type: checkboxes
-    id: updated
     attributes:
-      label: Typst version
-      description: Please check this box to confirm you are using the latest released version of Typst or an unreleased commit from this repository after the latest release.
+      label: 貢献意思
       options:
-        - label: I am using the latest version of Typst
+        - label: このIssueを解決するPull Requestの作成を自身で希望する場合はチェックしてください。
           required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: 💻 Web App Issues
-    url: https://github.com/typst/webapp-issues/issues
-    about: Bug reports or feature requests for Typst's official web app
-  - name: 💬 Typst Discord
-    url: https://discord.gg/2uDybryKPe
-    about: Get answers to your questions about Typst on our Discord server.
-  - name: 🗣️ Discussions on GitHub
-    url: https://github.com/typst/typst/discussions
-    about: Do you have a question instead of a specific bug or feature request? Open a discussion thread!
+  - name: Typst公式
+    url: https://github.com/typst/typst
+    about: 原文やTypst本体に対しての提案は公式のリポジトリにお問い合わせください。
+  - name: その他の提案
+    url: https://github.com/typst-jp/typst-jp.github.io/issues/new
+    about: 当てはまるものがない場合は、テンプレートを使用せずにIssueを作成できます。

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,25 +1,20 @@
-name: 🪴 Compiler Feature Request
-description: For feature request for the Typst compiler
-title: Write a short and descriptive title!
+name: ✨ 翻訳ドキュメントの新規追加の提案
+description: 翻訳ドキュメントの新規追加を提案するIssueを作成します。
 labels:
-  - feature request
+  - enhancement
 body:
   - type: markdown
     attributes:
-      value: Thanks for sharing your feature request for the Typst compiler. Did you [take a look](https://github.com/typst/typst/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+request%22+-label%3A%22web+app%22+) if a similar request has already been filed? If so, join the discussion there! Is your feature request related to Typst's web app? Please file it [here](https://github.com/typst/webapp-issues/issues) instead.
+      value: 翻訳ドキュメントの新規追加をご提案いただきありがとうございます。[Issueを作成する前に同様のIssueが既に存在しないかを確認してください。](https://github.com/typst-jp/typst-jp.github.io/issues?q=is%3Aopen)
   - type: textarea
-    id: description
     attributes:
-      label: Description
-      description: Please describe your feature request. You can also add a mockup if you are requesting a new output feature!
-      placeholder: Terse and specific description of the feature. You can add an image by dragging a file here.
+      label: 対象ドキュメント
+      description: 翻訳対象のドキュメントを記載してください。
     validations:
       required: true
-  - type: textarea
-    id: use-case
+  - type: checkboxes
     attributes:
-      label: Use Case
-      description: Please describe why this feature would be useful.
-      placeholder: Describe what users can accomplish with this feature and whom it might be useful for.
-    validations:
-      required: true
+      label: 貢献意思
+      options:
+        - label: このIssueを解決するPull Requestの作成を自身で希望する場合はチェックしてください。
+          required: false


### PR DESCRIPTION
close #13

上記のIssueに関連して、Issueテンプレートを翻訳プロジェクトに特化したものに変更しました。この変更を叩き台としてさまざまな意見を頂ければと思います。