### PR TITLE
chore: `context`をページとして登録

### DIFF
--- a/crates/typst-docs/src/lib.rs
+++ b/crates/typst-docs/src/lib.rs
@@ -148,6 +148,7 @@ fn reference_pages(resolver: &dyn Resolver) -> PageModel {
             .with_part("Language"),
         markdown_page(resolver, "/docs/reference/", "reference/styling.md"),
         markdown_page(resolver, "/docs/reference/", "reference/scripting.md"),
+        markdown_page(resolver, "/docs/reference/", "reference/context.md"),
         category_page(resolver, FOUNDATIONS).with_part("Library"),
         category_page(resolver, MODEL),
         category_page(resolver, TEXT),


### PR DESCRIPTION
リンクの resolve (#29) だけでは表示がまだできないらしいので、ここも変えないといけませんでした。