### PR TITLE
ci: pin cargo version to 1.77

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.79'
+          toolchain: '1.77'
       - uses: Swatinem/rust-cache@v2
       # python3 and package jinja2
       - uses: actions/setup-python@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.77'
       - uses: Swatinem/rust-cache@v2
       # python3 and package jinja2
       - uses: actions/setup-python@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: '1.77'
+          toolchain: '1.79'
       - uses: Swatinem/rust-cache@v2
       # python3 and package jinja2
       - uses: actions/setup-python@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: '1.77'
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Cargo のバージョンが 1.80 ではCIがコケていましたので、暫定的にバージョン 1.77 に固定しました。
根本的な解決としては [Cargo.toml](https://github.com/typst-jp/typst-jp.github.io/blob/719ab4b9a62360afb453cc3f5127ebfc511102a9/Cargo.toml) を整備して Cargo.lock を更新する必要がありそうです。