### PR TITLE
docs: Add manual progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Typst 日本語ドキュメント (非公式)
 
 [![CI/CD for Documentation](https://github.com/typst-jp/typst-jp.github.io/actions/workflows/deploy.yml/badge.svg?branch=main&event=push)](https://github.com/typst-jp/typst-jp.github.io/actions/workflows/deploy.yml)
+[![翻訳進捗](https://img.shields.io/badge/Translation%20Progress%20%2f%20翻訳進捗-28%25-orange.svg)](https://github.com/typst-jp/typst-jp.github.io/issues/44)
 
 > [!NOTE]
 > For English version, please refer to [README.en.md](README.en.md).


### PR DESCRIPTION
翻訳進捗を手動で追加しています。理想は自動化ですが、どうやらIssue APIにはIssueのタスク完成度データが含まれないっぽい（ほんまか？）から、手動でパースする必要がありそうです。