### PR TITLE
chore: Use title as `name` for non-ascii titles

### DIFF
--- a/docs/src/html.rs
+++ b/docs/src/html.rs
@@ -307,11 +307,17 @@ impl<'a> Handler<'a> {
 
         *id_slot = (!id.is_empty()).then_some(id);
 
-        // Special case for things like "v0.3.0".
+        let title = self.peeked.as_ref().map(|text| text.to_string());
         let name = if id.starts_with('v') && id.contains('.') {
+            // Special case for things like "v0.3.0".
             id.into()
-        } else {
+        } else if title.iter().all(|c| c.is_ascii()) {
             id.to_title_case().into()
+        } else {
+            self.ids
+                .alloc(title.expect("heading should always have a title"))
+                .as_str()
+                .into()
         };
 
         let mut children = &mut self.outline;


### PR DESCRIPTION
Fixes #46 

日本語の文字など英数字（ASCII）が含まれているMarkdown見出しに対し、`heck`パッケージの変換を通した`id`ではなく（通してしまうと英字以外が消されてしまうため）、そのまま`title`を使うようにしました。

`title`以外のものを目次にする場合は不便でしょうが、今のところ見出しをそのまま右に使っても構わないと判断したため、そのまま使うようにしました。また、`title`が長いことが多いので、Reactの日本語ドキュメントのように文字サイズを小さくするほうが将来的に良さそうかもしれません。

![image](https://github.com/user-attachments/assets/7f10375b-ce2a-46c0-b0b7-4ab6e0d89a1a)
