### PR TITLE
Restore glossary page

### DIFF
--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -93,6 +93,7 @@ pub fn provide(resolver: &dyn Resolver) -> Vec<PageModel> {
         reference_pages(resolver),
         guide_pages(resolver),
         changelog_pages(resolver),
+        md_page(resolver, base, load!("glossary.md")),
     ]
 }
 


### PR DESCRIPTION
- #62 のときに、気づけなくてすみません。
- glossaryのページが消えていたことに気づいたので修正しました。

v0.12.0のマージ前のコミットを見ると以下の通りで、

https://github.com/typst-jp/typst-jp.github.io/blob/4463badc4222b4e4fc4ff709168686a16e6d1774/docs/src/lib.rs#L88-L103

97行目の
```
packages_page(resolver), 
```
までは現在と同じで、
98行目の
```
md_page(resolver, base, load!("changelog.md")), 
```
は
```
changelog_pages(resolver),
```
に変更されています。
99, 100行目は https://github.com/typst-jp/typst-jp.github.io/pull/62#issue-2600243619 にありますように、削除されていて正常だと思います。

> upstreamの[v0.12.0](https://github.com/typst/typst/tree/v0.12.0)をマージした
RoadmapとCommunityのページは https://github.com/typst/typst/commit/cd02ae709f66742b6f50d6b84315feb8a7156d77#diff-6a17656d764b8e1930354f341cf7f47960b63845c3046edcd8bbf282aaa2f464 で削除された

以上の理解で、
```
md_page(resolver, base, load!("glossary.md")), 
```
のみ追記いたしました。
