### PR TITLE
Add git and openssh in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,7 @@ FROM rust:1.77-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    git openssh-client \
     curl \
     # install python3, jinja2 pyyaml
     python3 \


### PR DESCRIPTION
DevContainer内でもgitやGitHubを使いたい場面が多かったため追加してみました。
VS CodeではDevContainer内でのcommitなどの操作に対してはローカルの設定を使ってくれるため、コンテナ内でのgitの設定は不要でした。
pullやpushなどをするときにはssh接続しますので、そのクライアントが必要なようでした。
以上により、gitとopenssh-clientをapt-get installに加えました。

参考
https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials