### PR TITLE
fix: sidebarの開閉処理を有効化

### DIFF
--- a/static/scripts/docs.js
+++ b/static/scripts/docs.js
@@ -632,8 +632,8 @@ document.addEventListener("DOMContentLoaded", ()=>{
         setUpAccordeon(n);
     const t = document.querySelector("#page-overview > ul");
     t && setUpOnPageNavigation(t),
-    // setUpCollapsingSidebar(document.querySelector("nav.folding")),
-    alertClose(document.querySelector("button.close"));
+    setUpCollapsingSidebar(document.querySelector("nav.folding"));
+    //alertClose(document.querySelector("button.close"));
     for (const n of document.querySelectorAll("div.tooltip-context"))
         setUpTooltip(n);
     const e = document.querySelector(".page-end-buttons a.previous")


### PR DESCRIPTION
close #48

## 変更点

- sidebarの開閉処理のコメントアウトを外した

## 確認事項

- SPサイズの環境でsidebarの開閉ができる

## 備考

- PCでは[DevTools](https://developer.chrome.com/docs/devtools)でSPサイズでの挙動を確認できます