### PR TITLE
docs: 日本語ユーザーガイドの叩き台を作成

### DIFF
--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -23,10 +23,10 @@ description: |
 - [How-to-use-typst-for-paper-jp](https://github.com/kimushun1101/How-to-use-typst-for-paper-jp) - Typstの特徴と使い方、論文を書くときに使えるコード例をまとめた資料
 - [typst-jp-conf-template](https://github.com/kimushun1101/typst-jp-conf-template) - Typstで日本語論文を書くときのテンプレート
 - [master_thesis_template_for_typst](https://github.com/ut-khanlab/master_thesis_template_for_typst) - 修論用のTypstのテンプレート
+- [rinko_template_for_typst](https://github.com/hamataku/rinko_template_for_typst) - 東京大学電気系の輪講資料を作成するためのテンプレート
 - [ipsj-typst-template](https://github.com/mkpoli/ipsj-typst-template) - 情報処理学会（IPSJ）の研究報告テンプレート
 - [ipsj-national-convention-typst-template](https://github.com/kajiLabTeam/ipsj-national-convention-typst-template) - 情報処理学会全国大会テンプレート
-- [rinko_template_for_typst](https://github.com/hamataku/rinko_template_for_typst) - 東京大学電気系の輪講資料を作成するためのテンプレート
--
+- [Typst 備忘録 -自作書式のサンプル-](https://powercore.hatenablog.com/entry/2023/12/21/114030) - 電気学会全国大会テンプレート
 
 ### 学会
 

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -17,18 +17,15 @@ description: |
 
 ### 一般
 
-学会等が公式に案内しているテンプレートは[学会](#学会)を参照してください。ここには非公式のテンプレートが掲載されています。
-
 - [typst-jp-template](https://github.com/satshi/typst-jp-template) - pLaTeXでのjarticle風のとりあえず日本語で書き始めるためのテンプレート
 - [How-to-use-typst-for-paper-jp](https://github.com/kimushun1101/How-to-use-typst-for-paper-jp) - Typstの特徴と使い方、論文を書くときに使えるコード例をまとめた資料
 - [typst-jp-conf-template](https://github.com/kimushun1101/typst-jp-conf-template) - Typstで日本語論文を書くときのテンプレート
 - [master_thesis_template_for_typst](https://github.com/ut-khanlab/master_thesis_template_for_typst) - 修論用のTypstのテンプレート
 - [rinko_template_for_typst](https://github.com/hamataku/rinko_template_for_typst) - 東京大学電気系の輪講資料を作成するためのテンプレート
-- [ipsj-typst-template](https://github.com/mkpoli/ipsj-typst-template) - 情報処理学会（IPSJ）の研究報告テンプレート
-- [ipsj-national-convention-typst-template](https://github.com/kajiLabTeam/ipsj-national-convention-typst-template) - 情報処理学会全国大会テンプレート
-- [Typst 備忘録 -自作書式のサンプル-](https://powercore.hatenablog.com/entry/2023/12/21/114030) - 電気学会全国大会テンプレート
 
 ### 学会
+
+#### 公式
 
 - [第12回 制御部門マルチシンポジウム](https://mscs2025.sice-ctrl.jp/)
   - [https://mscs2025.sice-ctrl.jp/cfp](https://mscs2025.sice-ctrl.jp/cfp)
@@ -38,6 +35,14 @@ description: |
   - [https://github.com/kimushun1101/rengo2024-typst](https://github.com/kimushun1101/rengo2024-typst)
 - [第42回 日本ロボット学会学術講演会](https://ac.rsj-web.org/2024/)
   - [https://ac.rsj-web.org/2024/manuscript.html](https://ac.rsj-web.org/2024/manuscript.html)
+
+#### 非公式
+
+- 情報処理学会
+  - [ipsj-typst-template](https://github.com/mkpoli/ipsj-typst-template) - 情報処理学会（IPSJ）の研究報告テンプレート
+  - [ipsj-national-convention-typst-template](https://github.com/kajiLabTeam/ipsj-national-convention-typst-template) - 情報処理学会全国大会テンプレート
+- 電気学会
+  - [Typst 備忘録 -自作書式のサンプル-](https://powercore.hatenablog.com/entry/2023/12/21/114030) - 電気学会全国大会テンプレート
 
 ### 試験
 

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -62,12 +62,72 @@ description: |
 
 ## 記事
 
-- [Typstの記事一覧 | Zenn](https://zenn.dev/topics/typst)
-  - [Typstで日本語文字と英数字のフォントを別々に指定する](https://zenn.dev/mkpoli/articles/6234c1d2a595bd)
-  - [Typst最初の段落の字下げの調整方法](https://zenn.dev/mkpoli/articles/34a5ea47468979)
-  - [Typst で製本用PDF を作りたい](https://zenn.dev/nabetani/articles/c8deca489b4880)
-  - [Typst で和文と欧文の境界に隙間を入れる](https://zenn.dev/saito_atsushi/articles/db7e458fd3f49f)
-  - [Typst でルビをふる](https://zenn.dev/saito_atsushi/articles/ff9490458570e1)
-- [Typstとは？開発に役立つ使い方、トレンド記事やtips - Qiita](https://qiita.com/tags/typst)
-  - [Typst でも縦書きをして新年のご挨拶をしたい #Typst - Qiita](https://qiita.com/Yarakashi_Kikohshi/items/c3eeabfe918d2850abc0)
+Typstに関する日本語の記事は[Zenn](https://zenn.dev/)や[Qiita](https://qiita.com/)に沢山掲載されています。以下のリンクからその一覧が見られます。
+
+- [Typstの記事一覧 | Zenn](https://zenn.dev/topics/typst) - ZennのTypstトピック
+- [Typstとは？開発に役立つ使い方、トレンド記事やtips - Qiita](https://qiita.com/tags/typst) - QiitaのTypstタグ
+
+また、個人ブログ・ウィキサイトなどでもまとめられています。様々なプラットフォームから、いくつかピックアップしたものが以下に整理されています。
+
+### 総合入門
+
 - [Typst入門](https://okumuralab.org/~okumura/misc/241111.html) - LaTeX美文書作成入門の著者として知られる奥村晴彦氏によるTypst入門記事
+- [Typstの使い方](https://kumaroot.readthedocs.io/ja/latest/typst/typst-usage.html) - 「くまROOT」 by Shota TAKAHASHI
+- [Typst - TeX Wiki](https://texwiki.texjp.org/?Typst) - Tex Wiki
+- [組版処理システム Typst の紹介](https://itpass.scitec.kobe-u.ac.jp/~itpass/seminar/lecture/fy2024/241002/pub/itpass_seminar_20241002_typst.pdf) - 樫村博基（神戸大学）
+- [Typst を試す・学ぶための記事](https://www.metaphysica.info/2024/typst-guidance/) - 高校数学調律研究室
+- [Typst で技術同人誌を書く。](https://techbookfest.org/product/mSFLXEDy9TX7ymSmib198P?productVariantID=sPgvPBmuabt08PfCeC6E2B) - 技術書典17
+- [Typstで技術同人誌を書こう！すぐに役立つ20のトピック](https://techbookfest.org/product/3zT3xbGrxx4bdwSNGsD83e?productVariantID=VsMLWXRzNEC2YjyfPkeYh) - 技術書典17
+- [やりたいことから始めるTypst](https://qiita.com/tomoyatajika/items/649884befe95c5f1dcea) - @tomoyatajika
+- [[打倒LaTeX !!] 生まれたての組版システム'Typst'の使い方と便利な機能を実装した話(2023.10)](https://zenn.dev/taiiin02/articles/typst_articles_main) - @taiiin02
+- [新興組版システム typst のススメ](https://zenn.dev/msakuta/articles/2f1cd11d6099d6) - @msakuta
+- [これからLaTeXをするなら Typst はオススメ！](https://zenn.dev/saito_atsushi/articles/2b56f58c4fe3ca) - @saito_atsushi
+- [非プログラミング者のためのTypst公式ドキュメント攻略ガイド](https://zrbabbler.hatenablog.com/entry/2024/05/02/125454) - ZR-TeXnobabbler
+
+### 実践事例
+
+- [学校のレポートをTypstで書こう](https://zenn.dev/1step621/articles/b427a8ee518e26)
+- [Typstで試験の解答欄を作ってみた](https://zenn.dev/1step621/articles/df285be712d9d5)
+- [Typstでファイルを分割して本を書く](https://zenn.dev/kawaxumax/articles/bf629f56cc2928) 
+- [Quarto + Typstでアカデミックなスライドを作る](https://zenn.dev/nicetak/articles/quarto-typst-slides)
+- [Quarto + TypstでCVを自動で作る](https://zenn.dev/nicetak/articles/quarto-typst-cv)
+- [Rust製の組版システムTypstを使ってみた](https://zenn.dev/xbit/articles/bdb59d0081b2d3)
+- [polylux ～Typstでスライドを作ろう！！～](https://zenn.dev/k_84mo10/articles/how2use-polylux1)
+- [話題の組版エンジン Typst を触ってみた](https://zenn.dev/monaqa/articles/2023-04-19-typst-introduction)
+
+### 環境設定
+
+- [NeovimでTypstを書くための環境準備](https://zenn.dev/htsulfuric/articles/typst_and_nvim)
+- [typst の環境を WSL 上に作る (1)](https://zenn.dev/derwind/articles/dwd-typst-env01)
+
+### 和欧混植
+
+- [Typstで日本語文字と英数字のフォントを別々に指定する](https://zenn.dev/mkpoli/articles/6234c1d2a595bd)
+- [Typst で和文と欧文の境界に隙間を入れる](https://zenn.dev/saito_atsushi/articles/db7e458fd3f49f)
+- [Typst でも縦書きをして新年のご挨拶をしたい #Typst - Qiita](https://qiita.com/Yarakashi_Kikohshi/items/c3eeabfe918d2850abc0)
+- [Typst でルビをふる](https://zenn.dev/saito_atsushi/articles/ff9490458570e1)
+- [Typst最初の段落の字下げの調整方法](https://zenn.dev/mkpoli/articles/34a5ea47468979)
+- [Typst で製本用PDF を作りたい](https://zenn.dev/nabetani/articles/c8deca489b4880)
+
+### トリビア
+
+- [Typstにおける番号付け指南：基本から高度なカスタマイズまで](https://zenn.dev/mkpoli/articles/eff001d9e691cb)
+- [Typstで現時刻を取得する方法](https://zenn.dev/mkpoli/articles/b0e60a6bc07b10)
+- [Typstでリンク先のURLを脚注に出したい、自動で](https://zenn.dev/darashi/articles/f370ef5a2a7444)
+- [Typstでmermaidのsvgを文字を欠落させずに挿入する](https://zenn.dev/kake26s/articles/43b3ab90fde550)
+- [Typst の擬似コード用モジュールを作成した](https://zenn.dev/agdf/articles/cba8c6f29d4069)
+- [Typst コードを Mathlog マークアップに変換する(in Rust)](https://zenn.dev/arakur/articles/088643e7993449)
+- [Typst で短縮記法](https://zenn.dev/saito_atsushi/articles/4b7379eb2972bf)
+- [Typst で JSON をシンタクスハイライト](https://zenn.dev/kake26s/articles/43b3ab90fde550)
+- [覚えておくと便利なTypstの文法](https://oucc.org/blog/articles/1003/)
+- [Typstで転置など](https://ryokaneko.lsv.jp/2024/06/23/typst%E3%81%A7%E8%BB%A2%E7%BD%AE%E3%81%AA%E3%81%A9/)
+- [Typstで要素を横並びにして脚注にラベル付けする](https://idukn.com/tech/typst-labels/)
+- [Typstの空白について](https://event.phys.s.u-tokyo.ac.jp/physlab2024/advent-calendar/13/)
+- [Typst 便利パッケージと使用例の紹介](https://event.phys.s.u-tokyo.ac.jp/physlab2024/advent-calendar/8/)
+
+### 開発参加
+
+- [Typstの日本語Lipsumパッケージを作ってみた件](https://zenn.dev/mkpoli/articles/7e54c1c780ff43)
+- [Typstのimage関数にrotationパラメタを追加したかった話](https://zenn.dev/htsulfuric/articles/1e7ee5b0ccc223)
+- [WASMでTypstプラグインを作ろう](https://zenn.dev/nazo6/articles/wasm-typst-plugin)
+- [Typstで書く卒論・修論テンプレート](https://zenn.dev/chantakan/articles/ed80950004d145)

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -80,6 +80,8 @@ Typstに関する日本語の記事は[Zenn](https://zenn.dev/)や[Qiita](https:
 - [Typst で技術同人誌を書く。](https://techbookfest.org/product/mSFLXEDy9TX7ymSmib198P?productVariantID=sPgvPBmuabt08PfCeC6E2B) - 技術書典17
 - [Typstで技術同人誌を書こう！すぐに役立つ20のトピック](https://techbookfest.org/product/3zT3xbGrxx4bdwSNGsD83e?productVariantID=VsMLWXRzNEC2YjyfPkeYh) - 技術書典17
 - [やりたいことから始めるTypst](https://qiita.com/tomoyatajika/items/649884befe95c5f1dcea) - @tomoyatajika
+- [初めてのTypst：構文の基礎から応用](https://qiita.com/naoppy/items/55a0df837858e553d430) - Naoppy (@naoppy)
+- [Typstのここがすごい！！](https://qiita.com/hikoharu14142/items/aa8cfb70d079b0324fba) - @hikoharu14142
 - [\[打倒LaTeX !!\] 生まれたての組版システム'Typst'の使い方と便利な機能を実装した話(2023.10)](https://zenn.dev/taiiin02/articles/typst_articles_main) - @taiiin02
 - [新興組版システム typst のススメ](https://zenn.dev/msakuta/articles/2f1cd11d6099d6) - @msakuta
 - [これからLaTeXをするなら Typst はオススメ！](https://zenn.dev/saito_atsushi/articles/2b56f58c4fe3ca) - @saito_atsushi

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -76,6 +76,7 @@ Typstに関する日本語の記事は[Zenn](https://zenn.dev/)や[Qiita](https:
 - [Typst - TeX Wiki](https://texwiki.texjp.org/?Typst) - Tex Wiki
 - [組版処理システム Typst の紹介](https://itpass.scitec.kobe-u.ac.jp/~itpass/seminar/lecture/fy2024/241002/pub/itpass_seminar_20241002_typst.pdf) - 樫村博基（神戸大学）
 - [Typst を試す・学ぶための記事](https://www.metaphysica.info/2024/typst-guidance/) - 高校数学調律研究室
+- [Typstで論文を書く](https://kimushun1101.github.io/How-to-use-typst-for-paper-jp/How-to-use-typst-for-paper-jp.pdf) - Shunsuke Kimura (@kimushun1101)
 - [Typst で技術同人誌を書く。](https://techbookfest.org/product/mSFLXEDy9TX7ymSmib198P?productVariantID=sPgvPBmuabt08PfCeC6E2B) - 技術書典17
 - [Typstで技術同人誌を書こう！すぐに役立つ20のトピック](https://techbookfest.org/product/3zT3xbGrxx4bdwSNGsD83e?productVariantID=VsMLWXRzNEC2YjyfPkeYh) - 技術書典17
 - [やりたいことから始めるTypst](https://qiita.com/tomoyatajika/items/649884befe95c5f1dcea) - @tomoyatajika

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -22,6 +22,7 @@ description: |
 - [typst-jp-conf-template](https://github.com/kimushun1101/typst-jp-conf-template) - Typstで日本語論文を書くときのテンプレート
 - [master_thesis_template_for_typst](https://github.com/ut-khanlab/master_thesis_template_for_typst) - 修論用のTypstのテンプレート
 - [rinko_template_for_typst](https://github.com/hamataku/rinko_template_for_typst) - 東京大学電気系の輪講資料を作成するためのテンプレート
+- [academic-writing-templates](https://github.com/borh-lab/academic-writing-templates) - 大阪大学大学院の中間発表テンプレート
 
 ### 学会
 

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -5,4 +5,69 @@ description: |
 
 # 日本語ユーザーガイド
 
-WIP
+<div class="info-box">
+  <p>このページの内容は公式ドキュメントには含まれておらず、日本語コミュニティによって独自に追加されたものです。</p>
+</div>
+
+このページでは、Typstで日本語組版を行うユーザー向けの情報を提供します。有益な情報をお持ちの方は、ぜひIssueやPull Requestを通じて貢献してください。
+
+ここでは日本語に特化した情報を提供します。日本語だけに限らず、多言語を対象とする情報については、[Awesome Typst](https://github.com/qjcg/awesome-typst)などを参照してください。
+
+## テンプレート
+
+### 一般
+
+学会等が公式に案内しているテンプレートは[学会](#学会)を参照してください。ここには非公式のテンプレートが掲載されています。
+
+- [typst-jp-template](https://github.com/satshi/typst-jp-template) - pLaTeXでのjarticle風のとりあえず日本語で書き始めるためのテンプレート
+- [How-to-use-typst-for-paper-jp](https://github.com/kimushun1101/How-to-use-typst-for-paper-jp) - Typstの特徴と使い方、論文を書くときに使えるコード例をまとめた資料
+- [typst-jp-conf-template](https://github.com/kimushun1101/typst-jp-conf-template) - Typstで日本語論文を書くときのテンプレート
+- [master_thesis_template_for_typst](https://github.com/ut-khanlab/master_thesis_template_for_typst) - 修論用のTypstのテンプレート
+- [ipsj-typst-template](https://github.com/mkpoli/ipsj-typst-template) - 情報処理学会（IPSJ）の研究報告テンプレート
+- [ipsj-national-convention-typst-template](https://github.com/kajiLabTeam/ipsj-national-convention-typst-template) - 情報処理学会全国大会テンプレート
+- [rinko_template_for_typst](https://github.com/hamataku/rinko_template_for_typst) - 東京大学電気系の輪講資料を作成するためのテンプレート
+-
+
+### 学会
+
+- [第12回 制御部門マルチシンポジウム](https://mscs2025.sice-ctrl.jp/)
+  - [https://mscs2025.sice-ctrl.jp/cfp](https://mscs2025.sice-ctrl.jp/cfp)
+  - [https://github.com/kimushun1101/mscs2025-typst](https://github.com/kimushun1101/mscs2025-typst)
+- [第67回 自動制御連合講演会](https://rengo67.iscie.or.jp/)
+  - [https://rengo67.iscie.or.jp/info/manuscript_guidelne/](https://rengo67.iscie.or.jp/info/manuscript_guidelne/)
+  - [https://github.com/kimushun1101/rengo2024-typst](https://github.com/kimushun1101/rengo2024-typst)
+- [第42回 日本ロボット学会学術講演会](https://ac.rsj-web.org/2024/)
+  - [https://ac.rsj-web.org/2024/manuscript.html](https://ac.rsj-web.org/2024/manuscript.html)
+
+### 試験
+
+- [typst-anshere](https://github.com/1STEP621/typst-anshere) - 試験の解答欄を作るためのテンプレート
+
+### 設計書
+
+- [SoftwareDesignTypst](https://github.com/ctenopoma/SoftwareDesignTypst) - ソフトウェア設計書のテンプレート
+
+### 履歴書
+
+- [typst-ja-resume-template](https://github.com/Nikudanngo/typst-ja-resume-template) - 履歴書のテンプレート
+
+### 請求書
+
+- [inboisu](https://github.com/mkpoli/typst-inboisu) - 日本語の請求書を作成するためのテンプレート
+
+## パッケージ
+
+- [rubby](https://typst.app/universe/package/rubby) - ふりがなを振る
+- [roremu](https://typst.app/universe/package/roremu) - 日本語のダミーテキストを生成する
+
+## 記事
+
+- [Typstの記事一覧 | Zenn](https://zenn.dev/topics/typst)
+  - [Typstで日本語文字と英数字のフォントを別々に指定する](https://zenn.dev/mkpoli/articles/6234c1d2a595bd)
+  - [Typst最初の段落の字下げの調整方法](https://zenn.dev/mkpoli/articles/34a5ea47468979)
+  - [Typst で製本用PDF を作りたい](https://zenn.dev/nabetani/articles/c8deca489b4880)
+  - [Typst で和文と欧文の境界に隙間を入れる](https://zenn.dev/saito_atsushi/articles/db7e458fd3f49f)
+  - [Typst でルビをふる](https://zenn.dev/saito_atsushi/articles/ff9490458570e1)
+- [Typstとは？開発に役立つ使い方、トレンド記事やtips - Qiita](https://qiita.com/tags/typst)
+  - [Typst でも縦書きをして新年のご挨拶をしたい #Typst - Qiita](https://qiita.com/Yarakashi_Kikohshi/items/c3eeabfe918d2850abc0)
+- [Typst入門](https://okumuralab.org/~okumura/misc/241111.html) - LaTeX美文書作成入門の著者として知られる奥村晴彦氏によるTypst入門記事

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -79,7 +79,7 @@ Typstに関する日本語の記事は[Zenn](https://zenn.dev/)や[Qiita](https:
 - [Typst で技術同人誌を書く。](https://techbookfest.org/product/mSFLXEDy9TX7ymSmib198P?productVariantID=sPgvPBmuabt08PfCeC6E2B) - 技術書典17
 - [Typstで技術同人誌を書こう！すぐに役立つ20のトピック](https://techbookfest.org/product/3zT3xbGrxx4bdwSNGsD83e?productVariantID=VsMLWXRzNEC2YjyfPkeYh) - 技術書典17
 - [やりたいことから始めるTypst](https://qiita.com/tomoyatajika/items/649884befe95c5f1dcea) - @tomoyatajika
-- [[打倒LaTeX !!] 生まれたての組版システム'Typst'の使い方と便利な機能を実装した話(2023.10)](https://zenn.dev/taiiin02/articles/typst_articles_main) - @taiiin02
+- [\[打倒LaTeX !!\] 生まれたての組版システム'Typst'の使い方と便利な機能を実装した話(2023.10)](https://zenn.dev/taiiin02/articles/typst_articles_main) - @taiiin02
 - [新興組版システム typst のススメ](https://zenn.dev/msakuta/articles/2f1cd11d6099d6) - @msakuta
 - [これからLaTeXをするなら Typst はオススメ！](https://zenn.dev/saito_atsushi/articles/2b56f58c4fe3ca) - @saito_atsushi
 - [非プログラミング者のためのTypst公式ドキュメント攻略ガイド](https://zrbabbler.hatenablog.com/entry/2024/05/02/125454) - ZR-TeXnobabbler


### PR DESCRIPTION
cf. #9

## 変更点

- 本文が「WIP」のまま放置を続けるのは問題なので、日本語ユーザーガイドの叩き台を作成した

## 確認事項

- 叩き台の文章として適切である

## 備考

- 将来的には、現在のTypstでのCJK組版の課題や、よくある質問集などを追加しようと考えています