### PR TITLE
fix: 画面の横幅が`600px`以上のときにsidebarを閉じるボタンを非表示にするスタイルを追加

### DIFF
--- a/static/styles/docs.css
+++ b/static/styles/docs.css
@@ -192,6 +192,12 @@ nav>button.close {
   top: 24px
 }
 
+@media (min-width: 600px) {
+  nav>button.close {
+    display: none;
+  }
+}
+
 button.hamburger {
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
## 変更点

PCサイズの画面幅の環境において、ページの右上に位置している×ボタンは黄色のアラートを閉じるためのボタンのように見えますが、実際にはマークアップ上ではsidebarを閉じるためのボタンであり、#73 でsidebarの開閉のイベントを有効にしたことで、PCサイズの環境で意図しない挙動になってしまっていたため、画面の横幅が`600px`以上のときに×ボタンの要素を非表示にする対応を行いました。

## 確認事項

- SPサイズの環境でsidebarを開閉できる
- 画面の横幅が`600px`以上のときに×ボタンが表示されない