### PR TITLE
Update `.gitignore` to include `.venv` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ package-lock.json
 /assets/docs.json
 /dist
 
-# mise
+# Python
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ package-lock.json
 /assets/docs
 /assets/docs.json
 /dist
+
+# mise
+.venv


### PR DESCRIPTION
- #71 で環境構築すると.venvディレクトリが生成され、それがgit管理に入ってしまうので.gitignoreファイルに追記しました。
- `# mise`とコメントアウトをふりましたが、`# Python`や`# uv`の方がよいですかね？