### PR TITLE
Fix devcontainer to non root user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,17 @@
 # Rust v1.77 as a base image
 FROM rust:1.77-slim
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    git openssh-client \
-    curl \
-    # install python3, jinja2 pyyaml
-    python3 \
-    python3-pip \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        openssh-client \
+        python3 \
+        python3-pip \
     && python3 -m pip install --break-system-packages jinja2 PyYAML \
-    # install nodejs and serve
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g serve@14.2.3 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
-# Rust v1.77 as a base image
 FROM rust:1.77-slim
 
-RUN apt-get update \
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && chsh -s /bin/bash $USERNAME \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
         openssh-client \
@@ -13,3 +19,4 @@ RUN apt-get update \
 
 WORKDIR /workspace
 ENV PATH="/root/.cargo/bin:${PATH}"
+USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get update \
         python3 \
         python3-pip \
     && python3 -m pip install --break-system-packages jinja2 PyYAML \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.77-slim
 
-ARG USERNAME=vscode
+ARG USERNAME=typst-jp
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,8 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "forwardPorts": [3000],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && npx serve -n ./dist",
+  "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,6 @@
   "forwardPorts": [3000],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && npx serve -n ./dist"
+  "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && npx serve -n ./dist",
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "remoteUser": "vscode",
+  "remoteUser": "typst-jp",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
   "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "remoteUser": "vscode",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
   "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "gen: typst-jp documentation",
       "type": "shell",
-      "command": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && echo reload or open http://localhost:3000",
+      "command": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && echo reload or open http://localhost:8000",
       "problemMatcher": []
     }
   ]


### PR DESCRIPTION
- #69 でDevcontainer上でも開発が行えるようになりましたが、Devcontainer上でビルドしてしまうと生成物がroot権限で作られます。
- Devcontainer外で、例えば`mise run generate`などをするとファイルが上書きできずにエラーとなってしまいます。
- そのため https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user を参考に、rootでない一般ユーザーである`typst-jp`ユーザーを作成しました。
- `mise run preview`に合わせてWebサーバーのコマンドを`python3 -m http.server -d dist`に変更しました。それに伴いNode.jsのインストールは削除しました。 #83 が終わったら後追いでまた導入するかもしれませんが。
- `npx serve -n ./dist`ではポート番号が3000番でしたが、`python3 -m http.server -d dist`では8000番に変更されています。問題ないでしょうか？
- Ubuntu 22.04 ネイティブでテストした際に https://gist.github.com/Seasawher/18f5781e372e4fbe691ee8942828bd8e と同じ問題が発生したため、`"postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",`を追加しました。