### PR TITLE
fix: groupのテンプレートの見出しの不要な文字を削除

### DIFF
--- a/templates/group_template.html.j2
+++ b/templates/group_template.html.j2
@@ -3,7 +3,7 @@
 {% extends "base_template.html.j2" %}
 {% block content %}
 
-<h1 id="summary">{{ body['content']['title'] }}<!-- --> Calculation</h1>
+<h1 id="summary">{{ body['content']['title'] }}</h1>
 {{ body['content']['details'] | safe }}
 <h2 id="functions">Calculation</h2>
 {% for method in body['content']['functions'] %}


### PR DESCRIPTION
## 変更点

- [reference/math/variants/](https://typst-jp.github.io/docs/reference/math/variants/)などの`docs/reference/groups.yml`で管理されているページの見出しが本家と異なっていたため、テンプレートの見出しを修正した