### PR TITLE
chore: add textlint to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,7 @@ FROM rust:1.77-slim
 ARG USERNAME=typst-jp
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG BUN_VERSION=1.1.37
 
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
@@ -11,9 +12,12 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && apt-get install -y --no-install-recommends \
         git \
         openssh-client \
+        curl \
+        unzip \
         python3 \
         python3-pip \
     && python3 -m pip install --break-system-packages jinja2 PyYAML \
+    && su $USERNAME -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"' \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
 FROM rust:1.77-slim
 
-ARG USERNAME=typst-jp
+ARG USER_NAME=typst-jp
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ARG BUN_VERSION=1.1.37
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && chsh -s /bin/bash $USERNAME \
+RUN groupadd --gid $USER_GID $USER_NAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USER_NAME \
+    && chsh -s /bin/bash $USER_NAME \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -17,10 +17,10 @@ RUN groupadd --gid $USER_GID $USERNAME \
         python3 \
         python3-pip \
     && python3 -m pip install --break-system-packages jinja2 PyYAML \
-    && su $USERNAME -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"' \
+    && su $USER_NAME -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v$BUN_VERSION"' \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 ENV PATH="/root/.cargo/bin:${PATH}"
-USER $USERNAME
+USER $USER_NAME

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -3,28 +3,33 @@
 [Docker](https://docs.docker.com/)を用いてWebページの仕上がりを確認できます。
 以下の操作はDockerがインストール済み、かつDockerデーモンを起動していることが前提となります。
 
-
 ## VS Codeを使用している場合
 
 [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)を使用します。
 Visual Studio Codeでtypst-jp.github.ioディレクトリを開き、以下の操作を実施してください。
+
 1. Ctrl+Shift+Pから`> Dev Containers: Reopen in Container`を実行
-2. Webサーバーが起動したらブラウザで http://localhost:3000 に接続
-3. ページを更新した際には、Ctrl+Shift+Pから`> Tasks: Run task`を実行し`gen: typst-jp documentation`を選択。ビルドが完了したらブラウザを更新。
+2. Webサーバーが起動したらブラウザで http://localhost:8000 に接続
+3. ページを更新した際には、Ctrl+Shift+Pから`> Tasks: Run task`を実行し`generate-docs`を選択、ビルドが完了したらブラウザを更新
+4. 体裁を確認したい場合、同様に`> Tasks: Run task`を実行し`textlint-md`（markdownファイルを翻訳した場合）または`textlint-html`（Rustソースコードを翻訳した場合）を選択
+5. 自動修正を実施したい場合、markdownファイルの添削であれば、同様に`textlint-md:fix`を選択（Rustコードは対応していなため、該当箇所を手動で修正してください。）
 
 
 ## 別のエディターを使用している場合
 
 ターミナルからDockerfileをビルドして、コマンド実行します。
 typst-jp.github.io ディレクトリ上で以下のコマンドを実行してください。
+
 1. Docker imageをビルドしてコンテナを作成
     ```
     docker build . -f .devcontainer/Dockerfile -t typst-jp-doc
-    docker run --name typst-jp-doc -p 3000:3000 -it -v "$(pwd):/workspace" -w /workspace --rm typst-jp-doc /bin/bash
+    docker run --name typst-jp-doc -p 8000:8000 -it -v "$(pwd):/workspace" -w /workspace --rm typst-jp-doc /bin/bash
     ```
 2. Dockerコンテナ内でページを生成
     ```
     cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && npx serve -n ./dist
     ```
-3. Webサーバーが起動したらブラウザで http://localhost:3000 に接続
-4. ファイルを更新した際には、2 のコマンドを一旦 Ctrl+C で終了して再度実行、その後ブラウザを更新。
+3. Webサーバーが起動したらブラウザで http://localhost:8000 に接続
+4. ファイルを更新した際には、2 のコマンドを一旦 Ctrl+C で終了して再度実行、その後ブラウザを更新
+5. 体裁を確認したい場合には、初めの一回だけ`bun install --frozen-lockfile`を実行した後、`bun run textlint-md`や`bun run textlint-html`を実行
+6. markdownファイルの体裁を修正したい場合には`textlint-md:fix`を実行

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,6 @@
   "remoteUser": "typst-jp",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",
+  "postStartCommand": "bun install --frozen-lockfile && cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",
   "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,6 @@
   "remoteUser": "typst-jp",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "bun install --frozen-lockfile && cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist",
-  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "bun install --frozen-lockfile && cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && python3 -m http.server -d dist"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,9 +2,27 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "gen: typst-jp documentation",
+      "label": "generate-docs",
       "type": "shell",
       "command": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && echo reload or open http://localhost:8000",
+      "problemMatcher": []
+    },
+    {
+      "label": "textlint-md",
+      "type": "shell",
+      "command": "bun run textlint-md",
+      "problemMatcher": []
+    },
+    {
+      "label": "textlint-md:fix",
+      "type": "shell",
+      "command": "bun run textlint-md:fix",
+      "problemMatcher": []
+    },
+    {
+      "label": "textlint-html",
+      "type": "shell",
+      "command": "bun run textlint-html",
       "problemMatcher": []
     }
   ]


### PR DESCRIPTION
- Devcontainer内でも #83 で追加したtextlintを使用できるようにしました。
- `.vscode/tasks`からも実行できるようにしています。
- `.devcontainer/README.md`の内容が実行できるかご確認いただけますと幸いです。