### PR TITLE
chore: add build group property to generate-docs task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
       "group": {
         "kind": "build",
         "isDefault": true
-      },
+      }
     },
     {
       "label": "textlint-md",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,11 @@
       "label": "generate-docs",
       "type": "shell",
       "command": "cargo test --package typst-docs --lib -- tests::test_docs --exact --nocapture && python3 ./gen.py && echo reload or open http://localhost:8000",
-      "problemMatcher": []
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
     },
     {
       "label": "textlint-md",


### PR DESCRIPTION
VS Codeでgenerate-docsするタスクをデフォルトのビルドとして設定することで、ショートカットキー`Ctrl+Shift+B`で実行できるようしました。
参考：https://code.visualstudio.com/docs/editor/tasks#_typescript-hello-world