### PR TITLE
chore: Rustのバージョンを.mise.tomlに記載

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
+rust = "1.83.0"
 node = "22.11.0"
 bun = "1.1.37"
-rust = "1.81.0"
 
 [settings]
 yes = true

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [tools]
 node = "22.11.0"
 bun = "1.1.37"
+rust = "1.81.0"
 
 [settings]
 yes = true


### PR DESCRIPTION
以前他のissueかpull requestでもお聞きしましたが、miseにRustのバージョン管理も含めてもよいか再度ご検討いただけますでしょうか？
experimentalではありますが、Docker上で動作を確認できました。
https://mise.jdx.dev/lang/rust.html
もし他に悪影響を与えていなければ入れていただけますと幸いです。
- #138 の対応がやりやすくなります。

## 確認方法

https://mise.jdx.dev/mise-cookbook/docker.html を参考にDockerでmiseのコンテナーを作成

```
docker run --pull=always -it --rm --entrypoint bash jdxcode/mise:latest
```

docker内で以下のコマンドで環境構築

```
git clone -b feature/add-rust-in-mise https://github.com/typst-jp/typst-jp.github.io.git
cd typst-jp.github.io
mise trust
mise install
```

ビルドの確認

```
mise run generate
```

`mise run preview`を試すためには`docker run`にポート設定が必要になるかと思いますが、Rustに無関係かと思い試していません。

## 補足

[tools]に関して、推奨の記述順序あればご指示ください。