### PR TITLE
`/docs/reference/math/equation/`の翻訳

### DIFF
--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -84,7 +84,7 @@
 	"/docs/reference/math/cancel/": "untranslated",
 	"/docs/reference/math/cases/": "untranslated",
 	"/docs/reference/math/class/": "untranslated",
-	"/docs/reference/math/equation/": "untranslated",
+	"/docs/reference/math/equation/": "translated",
 	"/docs/reference/math/frac/": "untranslated",
 	"/docs/reference/math/lr": "untranslated",
 	"/docs/reference/math/mat/": "untranslated",


### PR DESCRIPTION
[reference/math/equation](https://typst.app/docs/reference/math/equation/)の翻訳です。