### PR TITLE
`/docs/reference/math/roots`の翻訳

### DIFF
--- a/crates/typst-library/src/math/root.rs
+++ b/crates/typst-library/src/math/root.rs
@@ -24,7 +24,7 @@ pub fn sqrt(
 /// ```
 #[elem(Mathy)]
 pub struct RootElem {
-    /// 被開平数の何乗根を取るか。
+    /// 被開方数の何乗根を取るか。
     #[positional]
     pub index: Option<Content>,
 

--- a/crates/typst-library/src/math/root.rs
+++ b/crates/typst-library/src/math/root.rs
@@ -24,7 +24,7 @@ pub fn sqrt(
 /// ```
 #[elem(Mathy)]
 pub struct RootElem {
-    /// 被開数の何乗根を取るか。
+    /// 被開平数の何乗根を取るか。
     #[positional]
     pub index: Option<Content>,
 

--- a/crates/typst-library/src/math/root.rs
+++ b/crates/typst-library/src/math/root.rs
@@ -3,7 +3,7 @@ use typst_syntax::Span;
 use crate::foundations::{elem, func, Content, NativeElement};
 use crate::math::Mathy;
 
-/// A square root.
+/// 平方根。
 ///
 /// ```example
 /// $ sqrt(3 - 2 sqrt(2)) = sqrt(2) - 1 $
@@ -11,24 +11,24 @@ use crate::math::Mathy;
 #[func(title = "Square Root")]
 pub fn sqrt(
     span: Span,
-    /// The expression to take the square root of.
+    /// 平方根を取る対象の式。
     radicand: Content,
 ) -> Content {
     RootElem::new(radicand).pack().spanned(span)
 }
 
-/// A general root.
+/// 一般的な累乗根。
 ///
 /// ```example
 /// $ root(3, x) $
 /// ```
 #[elem(Mathy)]
 pub struct RootElem {
-    /// Which root of the radicand to take.
+    /// 被開数の何乗根を取るか。
     #[positional]
     pub index: Option<Content>,
 
-    /// The expression to take the root of.
+    /// 根を取る対象の式。
     #[required]
     pub radicand: Content,
 }

--- a/crates/typst-library/src/math/root.rs
+++ b/crates/typst-library/src/math/root.rs
@@ -17,7 +17,7 @@ pub fn sqrt(
     RootElem::new(radicand).pack().spanned(span)
 }
 
-/// 一般的な累乗根。
+/// 累乗根。
 ///
 /// ```example
 /// $ root(3, x) $

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -63,9 +63,9 @@
   path: ["math"]
   filter: ["root", "sqrt"]
   details: |
-    Square and non-square roots.
+    平方根とその他の累乗根。
 
-    # Example
+    # 例
     ```example
     $ sqrt(3 - 2 sqrt(2)) = sqrt(2) - 1 $
     $ root(3, x) $

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -89,7 +89,7 @@
 	"/docs/reference/math/lr": "untranslated",
 	"/docs/reference/math/mat/": "untranslated",
 	"/docs/reference/math/primes/": "untranslated",
-	"/docs/reference/math/roots": "untranslated",
+	"/docs/reference/math/roots": "translated",
 	"/docs/reference/math/sizes": "untranslated",
 	"/docs/reference/math/stretch/": "untranslated",
 	"/docs/reference/math/styles": "untranslated",


### PR DESCRIPTION
[/math/roots](https://typst.app/docs/reference/math/roots)の翻訳です。