### PR TITLE
`/docs/reference/layout/hide`の翻訳

### DIFF
--- a/crates/typst-library/src/layout/hide.rs
+++ b/crates/typst-library/src/layout/hide.rs
@@ -2,21 +2,20 @@ use crate::diag::SourceResult;
 use crate::engine::Engine;
 use crate::foundations::{elem, Content, Packed, Show, StyleChain};
 
-/// Hides content without affecting layout.
+/// レイアウトに影響を与えないコンテンツの隠蔽。
 ///
-/// The `hide` function allows you to hide content while the layout still 'sees'
-/// it. This is useful to create whitespace that is exactly as large as some
-/// content. It may also be useful to redact content because its arguments are
-/// not included in the output.
+/// `hide`関数を用いると、レイアウトにコンテンツを「認識」させながらコンテンツを隠すことができます。
+/// これは何らかのコンテンツと全く同じ大きさを持つ空白を作る際に便利です。
+/// 引数が出力に含まれないため、コンテンツを削除する際にも便利かもしれません。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// Hello Jane \
 /// #hide[Hello] Joe
 /// ```
 #[elem(Show)]
 pub struct HideElem {
-    /// The content to hide.
+    /// 隠したいコンテンツ。
     #[required]
     pub body: Content,
 

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -111,7 +111,7 @@
 	"/docs/reference/layout/direction/": "untranslated",
 	"/docs/reference/layout/fraction/": "untranslated",
 	"/docs/reference/layout/grid/": "untranslated",
-	"/docs/reference/layout/hide/": "untranslated",
+	"/docs/reference/layout/hide/": "translated",
 	"/docs/reference/layout/layout/": "untranslated",
 	"/docs/reference/layout/length/": "untranslated",
 	"/docs/reference/layout/measure/": "untranslated",


### PR DESCRIPTION
[`layout/hide`](https://typst.app/docs/reference/layout/hide/)の翻訳です。