### PR TITLE
ci: WebサイトのCIにrust-cacheを追加

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: jdx/mise-action@13abe502c30c1559a5c37dff303831bab82c9402 # v2.2.3
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - run: mise run generate-docs
       - run: mise run generate-web
       - name: Upload build artifacts


### PR DESCRIPTION
WebサイトのCIでのCargoの依存関係の解決を高速化するために、[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)を導入しました。