### PR TITLE
fix: 目次のリンクのスクロール位置を調整

### DIFF
--- a/website/src/components/templates/BaseTemplate.tsx
+++ b/website/src/components/templates/BaseTemplate.tsx
@@ -41,7 +41,7 @@ export const BaseTemplate: FC<BaseTemplateProps> = ({
 	const outline = page.outline;
 	const translationStatus = getTranslationStatus(route);
 	return (
-		<html lang="ja">
+		<html lang="ja" class="scroll-pt-24">
 			<head>
 				<meta charSet="utf-8" />
 				<title>{title} – Typstドキュメント日本語版</title>


### PR DESCRIPTION
目次のリンクから見出しへ移動する際に、ヘッダーに被らない適切な位置にスクロールするよう修正しました。