### PR TITLE
`/docs/reference/data-loading/csv/`の翻訳

### DIFF
--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -153,7 +153,7 @@
 	"/docs/reference/introspection/state/": "untranslated",
 	"/docs/reference/data-loading/": "untranslated",
 	"/docs/reference/data-loading/cbor/": "untranslated",
-	"/docs/reference/data-loading/csv/": "untranslated",
+	"/docs/reference/data-loading/csv/": "translated",
 	"/docs/reference/data-loading/json/": "untranslated",
 	"/docs/reference/data-loading/read/": "untranslated",
 	"/docs/reference/data-loading/toml/": "untranslated",


### PR DESCRIPTION
[reference/data-loading/csv/](https://typst.app/docs/reference/data-loading/csv/)の翻訳です。