### PR TITLE
`/docs/reference/layout/repeat`の翻訳

### DIFF
--- a/crates/typst-library/src/layout/repeat.rs
+++ b/crates/typst-library/src/layout/repeat.rs
@@ -3,17 +3,15 @@ use crate::engine::Engine;
 use crate::foundations::{elem, Content, NativeElement, Packed, Show, StyleChain};
 use crate::layout::{BlockElem, Length};
 
-/// Repeats content to the available space.
+/// 利用可能なスペースでのコンテンツの繰り返し。
 ///
-/// This can be useful when implementing a custom index, reference, or outline.
+/// これは独自の索引、参考文献、目次を作成する場合に便利かもしれません。
 ///
-/// Space may be inserted between the instances of the body parameter, so be
-/// sure to adjust the [`justify`]($repeat.justify) parameter accordingly.
+/// bodyパラメーターの実体の間に空白が挿入される可能性があるため、[`justify`]($repeat.justify)パラメーターを正しく調整しているか確かめてください。
 ///
-/// Errors if there are no bounds on the available space, as it would create
-/// infinite content.
+/// 利用可能なスペースに上限がない場合は、コンテンツを無限に生成してしまうためエラーになります。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// Sign on the dotted line:
 /// #box(width: 1fr, repeat[.])
@@ -26,16 +24,15 @@ use crate::layout::{BlockElem, Length};
 /// ```
 #[elem(Show)]
 pub struct RepeatElem {
-    /// The content to repeat.
+    /// 繰り返すコンテンツ。
     #[required]
     pub body: Content,
 
-    /// The gap between each instance of the body.
+    /// 本文の実体間の間隔。
     #[default]
     pub gap: Length,
 
-    /// Whether to increase the gap between instances to completely fill the
-    /// available space.
+    /// 利用可能なスペースを完全に埋めるために、実体間の間隔を大きくするかどうか。
     #[default(true)]
     pub justify: bool,
 }

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -122,7 +122,7 @@
 	"/docs/reference/layout/place/": "translated",
 	"/docs/reference/layout/ratio/": "untranslated",
 	"/docs/reference/layout/relative/": "untranslated",
-	"/docs/reference/layout/repeat/": "untranslated",
+	"/docs/reference/layout/repeat/": "translated",
 	"/docs/reference/layout/rotate/": "untranslated",
 	"/docs/reference/layout/scale/": "untranslated",
 	"/docs/reference/layout/skew/": "untranslated",


### PR DESCRIPTION
[layout/repeat](https://typst.app/docs/reference/layout/repeat/)の翻訳です。