### PR TITLE
`/docs/reference/math/cancel`の翻訳

### DIFF
--- a/crates/typst-library/src/math/cancel.rs
+++ b/crates/typst-library/src/math/cancel.rs
@@ -3,11 +3,11 @@ use crate::layout::{Abs, Angle, Length, Ratio, Rel};
 use crate::math::Mathy;
 use crate::visualize::Stroke;
 
-/// Displays a diagonal line over a part of an equation.
+/// 数式の一部分上に対角線を表示。
 ///
-/// This is commonly used to show the elimination of a term.
+/// 項の除去を示すのによく使われます。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// >>> #set page(width: 140pt)
 /// Here, we can simplify:
@@ -16,13 +16,12 @@ use crate::visualize::Stroke;
 /// ```
 #[elem(Mathy)]
 pub struct CancelElem {
-    /// The content over which the line should be placed.
+    /// 線が配置されるべきコンテンツ。
     #[required]
     pub body: Content,
 
-    /// The length of the line, relative to the length of the diagonal spanning
-    /// the whole element being "cancelled". A value of `{100%}` would then have
-    /// the line span precisely the element's diagonal.
+    /// 「キャンセル」したい要素全体をまたぐ対角線を基準とした相対的な線の長さ。
+    /// `{100%}`という値は、要素の対角線と正確に一致する長さになります。
     ///
     /// ```example
     /// >>> #set page(width: 140pt)
@@ -33,9 +32,8 @@ pub struct CancelElem {
     #[default(Rel::new(Ratio::one(), Abs::pt(3.0).into()))]
     pub length: Rel<Length>,
 
-    /// Whether the cancel line should be inverted (flipped along the y-axis).
-    /// For the default angle setting, inverted means the cancel line
-    /// points to the top left instead of top right.
+    /// 打ち消し線を（y軸に関して）反転させるべきかどうか。
+    /// デフォルト角度設定では、反転は、打ち消し線が右上を指す代わりに左上を指すことを意味します。
     ///
     /// ```example
     /// >>> #set page(width: 140pt)
@@ -45,8 +43,8 @@ pub struct CancelElem {
     #[default(false)]
     pub inverted: bool,
 
-    /// Whether two opposing cancel lines should be drawn, forming a cross over
-    /// the element. Overrides `inverted`.
+    /// 要素上で交差する、相対する2つの打ち消し線を描画するかどうか。
+    /// これは`inverted`を上書きします。
     ///
     /// ```example
     /// >>> #set page(width: 140pt)
@@ -55,15 +53,12 @@ pub struct CancelElem {
     #[default(false)]
     pub cross: bool,
 
-    /// How much to rotate the cancel line.
+    /// 打ち消し線をどれくらい回転させるか。
     ///
-    /// - If given an angle, the line is rotated by that angle clockwise with
-    ///   respect to the y-axis.
-    /// - If `{auto}`, the line assumes the default angle; that is, along the
-    ///   rising diagonal of the content box.
-    /// - If given a function `angle => angle`, the line is rotated, with
-    ///   respect to the y-axis, by the angle returned by that function. The
-    ///   function receives the default angle as its input.
+    /// - 角度が与えられた場合、y軸を角度の基準にして時計回りに与えられた角度だけ線が回転します。
+    /// - `{auto}`の場合、デフォルトの角度を用いた線となります。すなわち、コンテンツのボックスの右上がりの対角線に沿うものになります。
+    /// - `angle => angle`の形の関数が与えられた場合、その関数が返すy軸を角度の基準にした角度で線が回転します。
+    /// 関数は入力としてデフォルトの角度を受け取ります。
     ///
     /// ```example
     /// >>> #set page(width: 140pt)
@@ -76,7 +71,7 @@ pub struct CancelElem {
     /// ```
     pub angle: Smart<CancelAngle>,
 
-    /// How to [stroke]($stroke) the cancel line.
+    /// 打ち消し線の[ストローク]($stroke)をどうするか。
     ///
     /// ```example
     /// >>> #set page(width: 140pt)

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -81,7 +81,7 @@
 	"/docs/reference/math/accent/": "translated",
 	"/docs/reference/math/attach/": "untranslated",
 	"/docs/reference/math/binom/": "untranslated",
-	"/docs/reference/math/cancel/": "untranslated",
+	"/docs/reference/math/cancel/": "translated",
 	"/docs/reference/math/cases/": "untranslated",
 	"/docs/reference/math/class/": "untranslated",
 	"/docs/reference/math/equation/": "translated",


### PR DESCRIPTION
[math/cancel](https://typst.app/docs/reference/math/cancel)の翻訳です。