### PR TITLE
`/docs/reference/math/lr`の翻訳

### DIFF
--- a/crates/typst-library/src/math/lr.rs
+++ b/crates/typst-library/src/math/lr.rs
@@ -2,18 +2,17 @@ use crate::foundations::{elem, func, Content, NativeElement, SymbolElem};
 use crate::layout::{Length, Rel};
 use crate::math::Mathy;
 
-/// Scales delimiters.
+/// 区切り文字の拡大縮小。
 ///
-/// While matched delimiters scale by default, this can be used to scale
-/// unmatched delimiters and to control the delimiter scaling more precisely.
+/// 閉じている区切り文字はデフォルトで拡大縮小しますが、これは閉じていない区切り文字を拡大縮小させたり、区切り文字の拡大縮小をより正確に制御するのに便利です。
 #[elem(title = "Left/Right", Mathy)]
 pub struct LrElem {
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[resolve]
     #[default(Rel::one())]
     pub size: Rel<Length>,
 
-    /// The delimited content, including the delimiters.
+    /// 区切り文字を含めた、区切られるコンテンツ。
     #[required]
     #[parse(
         let mut arguments = args.all::<Content>()?.into_iter();
@@ -24,93 +23,93 @@ pub struct LrElem {
     pub body: Content,
 }
 
-/// Scales delimiters vertically to the nearest surrounding `{lr()}` group.
+/// 最も近くで囲んでいる`{lr()}`グループに対して、垂直方向に区切り文字を拡大縮小します。
 ///
 /// ```example
 /// $ { x mid(|) sum_(i=1)^n w_i|f_i (x)| < 1 } $
 /// ```
 #[elem(Mathy)]
 pub struct MidElem {
-    /// The content to be scaled.
+    /// 拡大縮小させるコンテンツ。
     #[required]
     pub body: Content,
 }
 
-/// Floors an expression.
+/// 式に床関数を作用させます。
 ///
 /// ```example
 /// $ floor(x/2) $
 /// ```
 #[func]
 pub fn floor(
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[named]
     size: Option<Rel<Length>>,
-    /// The expression to floor.
+    /// 床関数を作用させる式。
     body: Content,
 ) -> Content {
     delimited(body, '⌊', '⌋', size)
 }
 
-/// Ceils an expression.
+/// 式に天井関数を作用させます。
 ///
 /// ```example
 /// $ ceil(x/2) $
 /// ```
 #[func]
 pub fn ceil(
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[named]
     size: Option<Rel<Length>>,
-    /// The expression to ceil.
+    /// 天井関数を作用させる式。
     body: Content,
 ) -> Content {
     delimited(body, '⌈', '⌉', size)
 }
 
-/// Rounds an expression.
+/// 式を丸めます。
 ///
 /// ```example
 /// $ round(x/2) $
 /// ```
 #[func]
 pub fn round(
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[named]
     size: Option<Rel<Length>>,
-    /// The expression to round.
+    /// 丸める式。
     body: Content,
 ) -> Content {
     delimited(body, '⌊', '⌉', size)
 }
 
-/// Takes the absolute value of an expression.
+/// 式の絶対値を取ります。
 ///
 /// ```example
 /// $ abs(x/2) $
 /// ```
 #[func]
 pub fn abs(
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[named]
     size: Option<Rel<Length>>,
-    /// The expression to take the absolute value of.
+    /// 絶対値を取る式。
     body: Content,
 ) -> Content {
     delimited(body, '|', '|', size)
 }
 
-/// Takes the norm of an expression.
+/// 式のノルムを取ります。
 ///
 /// ```example
 /// $ norm(x/2) $
 /// ```
 #[func]
 pub fn norm(
-    /// The size of the brackets, relative to the height of the wrapped content.
+    /// ラップしたコンテンツの高さを基準とした括弧の大きさ。
     #[named]
     size: Option<Rel<Length>>,
-    /// The expression to take the norm of.
+    /// ノルムを取る式。
     body: Content,
 ) -> Content {
     delimited(body, '‖', '‖', size)

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -39,18 +39,19 @@
   title: Under/Over
   category: math
   path: ["math"]
-  filter: [
-    "underline",
-    "overline",
-    "underbrace",
-    "overbrace",
-    "underbracket",
-    "overbracket",
-    "underparen",
-    "overparen",
-    "undershell",
-    "overshell",
-  ]
+  filter:
+    [
+      "underline",
+      "overline",
+      "underbrace",
+      "overbrace",
+      "underbracket",
+      "overbracket",
+      "underparen",
+      "overparen",
+      "undershell",
+      "overshell",
+    ]
   details: |
     Delimiters above or below parts of an equation.
 
@@ -103,16 +104,12 @@
   path: ["math"]
   filter: ["lr", "mid", "abs", "norm", "floor", "ceil", "round"]
   details: |
-    Delimiter matching.
+    区切り文字の対応
 
-    The `lr` function allows you to match two delimiters and scale them with the
-    content they contain. While this also happens automatically for delimiters
-    that match syntactically, `lr` allows you to match two arbitrary delimiters
-    and control their size exactly. Apart from the `lr` function, Typst provides
-    a few more functions that create delimiter pairings for absolute, ceiled,
-    and floored values as well as norms.
-
-    # Example
+    `lr`関数を用いると、2つの区切り文字を対応させ、内部のコンテンツに合わせた大きさに拡大縮小できます。
+    これは構文的に対応が取れる区切り文字においては自動的に行われますが、`lr`を用いることで2つの任意の区切り文字を対応させ、その大きさを正確に制御することができます。
+    `lr`関数以外にも、Typstは、絶対値、切り捨て値、切り上げ値、ノルムを表す区切り文字ペアを生成する関数をさらにいくつか提供しています。
+    # 例
     ```example
     $ [a, b/2] $
     $ lr(]sum_(x=1)^n], size: #50%) x $

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -86,7 +86,7 @@
 	"/docs/reference/math/class/": "untranslated",
 	"/docs/reference/math/equation/": "translated",
 	"/docs/reference/math/frac/": "translated",
-	"/docs/reference/math/lr/": "untranslated",
+	"/docs/reference/math/lr/": "translated",
 	"/docs/reference/math/mat/": "untranslated",
 	"/docs/reference/math/primes/": "untranslated",
 	"/docs/reference/math/roots/": "translated",


### PR DESCRIPTION
[math/lr](https://typst.app/docs/reference/math/lr)の翻訳です。