### PR TITLE
`/docs/reference/math/op`の翻訳

### DIFF
--- a/crates/typst-library/src/math/op.rs
+++ b/crates/typst-library/src/math/op.rs
@@ -5,28 +5,25 @@ use crate::layout::HElem;
 use crate::math::{upright, Mathy, THIN};
 use crate::text::TextElem;
 
-/// A text operator in an equation.
+/// 数式中のテキスト演算子。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// $ tan x = (sin x)/(cos x) $
 /// $ op("custom",
 ///      limits: #true)_(n->oo) n $
 /// ```
 ///
-/// # Predefined Operators { #predefined }
-/// Typst predefines the operators `arccos`, `arcsin`, `arctan`, `arg`, `cos`,
-/// `cosh`, `cot`, `coth`, `csc`, `csch`, `ctg`, `deg`, `det`, `dim`, `exp`,
-/// `gcd`, `lcm`, `hom`, `id`, `im`, `inf`, `ker`, `lg`, `lim`, `liminf`,
-/// `limsup`, `ln`, `log`, `max`, `min`, `mod`, `Pr`, `sec`, `sech`, `sin`,
-/// `sinc`, `sinh`, `sup`, `tan`, `tanh`, `tg` and `tr`.
+/// # 定義済み演算子 { #predefined }
+/// Typstが事前に定義してある演算子は以下の通りです。
+/// `arccos`、`arcsin`、`arctan`、`arg`、`cos`、`cosh`、`cot`、`coth`、`csc`、`csch`、`ctg`、`deg`、`det`、`dim`、`exp`、`gcd`、`lcm`、`hom`、`id`、`im`、`inf`、`ker`、`lg`、`lim`、`liminf`、`limsup`、`ln`、`log`、`max`、`min`、`mod`、`Pr`、`sec`、`sech`、`sin`、`sinc`、`sinh`、`sup`、`tan`、`tanh`、`tg`、`tr`。
 #[elem(title = "Text Operator", Mathy)]
 pub struct OpElem {
-    /// The operator's text.
+    /// 演算子のテキスト。
     #[required]
     pub text: Content,
 
-    /// Whether the operator should show attachments as limits in display mode.
+    /// ディスプレイモードのときに演算子のアタッチメントをlimitsのように表示するかどうか。
     #[default(false)]
     pub limits: bool,
 }

--- a/crates/typst-library/src/math/op.rs
+++ b/crates/typst-library/src/math/op.rs
@@ -15,7 +15,7 @@ use crate::text::TextElem;
 /// ```
 ///
 /// # 定義済み演算子 { #predefined }
-/// Typstが事前に定義してある演算子は以下の通りです。
+/// Typstではあらかじめ以下の演算子が定義されています。
 /// `arccos`、`arcsin`、`arctan`、`arg`、`cos`、`cosh`、`cot`、`coth`、`csc`、`csch`、`ctg`、`deg`、`det`、`dim`、`exp`、`gcd`、`lcm`、`hom`、`id`、`im`、`inf`、`ker`、`lg`、`lim`、`liminf`、`limsup`、`ln`、`log`、`max`、`min`、`mod`、`Pr`、`sec`、`sech`、`sin`、`sinc`、`sinh`、`sup`、`tan`、`tanh`、`tg`、`tr`。
 #[elem(title = "Text Operator", Mathy)]
 pub struct OpElem {

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -93,7 +93,7 @@
 	"/docs/reference/math/sizes/": "untranslated",
 	"/docs/reference/math/stretch/": "untranslated",
 	"/docs/reference/math/styles/": "untranslated",
-	"/docs/reference/math/op/": "untranslated",
+	"/docs/reference/math/op/": "translated",
 	"/docs/reference/math/underover/": "untranslated",
 	"/docs/reference/math/variants/": "untranslated",
 	"/docs/reference/math/vec/": "untranslated",


### PR DESCRIPTION
[math/op](https://typst.app/docs/reference/math/op)の翻訳です。