### PR TITLE
`/docs/reference/math/attach`の翻訳

### DIFF
--- a/crates/typst-library/src/math/attach.rs
+++ b/crates/typst-library/src/math/attach.rs
@@ -2,7 +2,7 @@ use crate::foundations::{elem, Content, Packed};
 use crate::layout::{Length, Rel};
 use crate::math::{EquationElem, Mathy};
 
-/// A base with optional attachments.
+/// オプションのアタッチメントを持つベースとなる関数。
 ///
 /// ```example
 /// $ attach(
@@ -12,33 +12,30 @@ use crate::math::{EquationElem, Mathy};
 /// ```
 #[elem(Mathy)]
 pub struct AttachElem {
-    /// The base to which things are attached.
+    /// アタッチメントを取り付けるベース。
     #[required]
     pub base: Content,
 
-    /// The top attachment, smartly positioned at top-right or above the base.
+    /// 右上かベースの上にスマート配置された上部アタッチメント。
     ///
-    /// You can wrap the base in `{limits()}` or `{scripts()}` to override the
-    /// smart positioning.
+    /// ベースを`{limits()}`か`{scripts()}`でラップするとスマート配置を上書きできます。
     pub t: Option<Content>,
 
-    /// The bottom attachment, smartly positioned at the bottom-right or below
-    /// the base.
+    /// 右下かベースの下にスマート配置された下部アタッチメント。
     ///
-    /// You can wrap the base in `{limits()}` or `{scripts()}` to override the
-    /// smart positioning.
+    /// ベースを`{limits()}`か`{scripts()}`でラップするとスマート配置を上書きできます。
     pub b: Option<Content>,
 
-    /// The top-left attachment (before the base).
+    /// 左上のアタッチメント（ベースの前）。
     pub tl: Option<Content>,
 
-    /// The bottom-left attachment (before base).
+    /// 左下のアタッチメント（ベースの前）。
     pub bl: Option<Content>,
 
-    /// The top-right attachment (after the base).
+    /// 右上のアタッチメント（ベースの後）。
     pub tr: Option<Content>,
 
-    /// The bottom-right attachment (after the base).
+    /// 右下のアタッチメント（ベースの後）。
     pub br: Option<Content>,
 }
 
@@ -98,33 +95,32 @@ pub struct PrimesElem {
     pub count: usize,
 }
 
-/// Forces a base to display attachments as scripts.
+/// アタッチメントを添え字として表示することをベースに強制。
 ///
 /// ```example
 /// $ scripts(sum)_1^2 != sum_1^2 $
 /// ```
 #[elem(Mathy)]
 pub struct ScriptsElem {
-    /// The base to attach the scripts to.
+    /// 添え字を取り付けるベース。
     #[required]
     pub body: Content,
 }
 
-/// Forces a base to display attachments as limits.
+/// アタッチメントをlimitsとして表示することをベースに強制。
 ///
 /// ```example
 /// $ limits(A)_1^2 != A_1^2 $
 /// ```
 #[elem(Mathy)]
 pub struct LimitsElem {
-    /// The base to attach the limits to.
+    /// limitsを取り付けるベース。
     #[required]
     pub body: Content,
 
-    /// Whether to also force limits in inline equations.
+    /// インライン数式でもlimits表示を強制するかどうか。
     ///
-    /// When applying limits globally (e.g., through a show rule), it is
-    /// typically a good idea to disable this.
+    /// （例えばshowルールを用いて）limitsをグローバルに適用する場合、通常は無効にすることをおすすめします。
     #[default(true)]
     pub inline: bool,
 }

--- a/docs/reference/groups.yml
+++ b/docs/reference/groups.yml
@@ -77,25 +77,21 @@
   path: ["math"]
   filter: ["attach", "scripts", "limits"]
   details: |
-    Subscript, superscripts, and limits.
+    下付き文字、上付き文字、limits。
 
-    Attachments can be displayed either as sub/superscripts, or limits. Typst
-    automatically decides which is more suitable depending on the base, but you
-    can also control this manually with the `scripts` and `limits` functions.
+    アタッチメントは下付き文字、上付き文字、limitsのいずれかで表示することができます。
+    Typstはベースに応じてどれがよりふさわしいかを自動的に決定しますが、`scripts`および`limits`関数を用いて手動で制御もできます。
 
-    If you want the base to stretch to fit long top and bottom attachments (for
-    example, an arrow with text above it), use the [`stretch`]($math.stretch)
-    function.
+    上部と下部の長いアタッチメント（例えば上部に文字がある矢印）に合うようにベースを伸縮させたい場合は[`stretch`]($math.stretch)関数を使用してください。
 
-    # Example
+    # 例
     ```example
     $ sum_(i=0)^n a_i = 2^(1+i) $
     ```
 
-    # Syntax
-    This function also has dedicated syntax for attachments after the base: Use
-    the underscore (`_`) to indicate a subscript i.e. bottom attachment and the
-    hat (`^`) to indicate a superscript i.e. top attachment.
+    # 構文
+    この関数にはベースの後ろのアタッチメントのための専用の構文があります。
+    下付き文字、すなわち下部のアタッチメントにはアンダースコア（`_`）を、上付き文字、すなわち上部のアタッチメントにはサーカムフレックス（`^`）を使用してください。
 
 - name: lr
   title: Left/Right

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -79,7 +79,7 @@
 	"/docs/reference/text/upper/": "untranslated",
 	"/docs/reference/math/": "untranslated",
 	"/docs/reference/math/accent/": "translated",
-	"/docs/reference/math/attach/": "untranslated",
+	"/docs/reference/math/attach/": "translated",
 	"/docs/reference/math/binom/": "untranslated",
 	"/docs/reference/math/cancel/": "untranslated",
 	"/docs/reference/math/cases/": "translated",


### PR DESCRIPTION
[math/attach](https://typst.app/docs/reference/math/attach)の翻訳です。