### PR TITLE
docs: Typst Japan CommunityをTypst Japanese Communityに置換

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # 貢献ガイドライン
 
 > [!NOTE]
-> 当プロジェクトの[README](./README.md)や「[はじめに：Typst Japan Communityより](https://typst-jp.github.io/docs/)」、[Typst公式](https://typst.app/)の[ライセンス](https://github.com/typst/typst/blob/main/LICENSE)や[コントリビューション・ガイド](https://github.com/typst/typst/blob/main/CONTRIBUTING.md)も併せてご参照ください。
+> 当プロジェクトの[README](./README.md)や「[はじめに：Typst Japanese Communityより](https://typst-jp.github.io/docs/)」、[Typst公式](https://typst.app/)の[ライセンス](https://github.com/typst/typst/blob/main/LICENSE)や[コントリビューション・ガイド](https://github.com/typst/typst/blob/main/CONTRIBUTING.md)も併せてご参照ください。
 
 Typst日本語ドキュメント翻訳プロジェクトにご興味をお持ちいただき、どうもありがとうございます。
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -7,11 +7,11 @@ description: |
 
 <div class="info-box">
 
-**はじめに: Typst Japan Communityより**
+**はじめに: Typst Japanese Communityより**
 
 日本語版Typstのドキュメントへようこそ！ [Typst](https://typst.app/) はアカデミック・ライティング用途を念頭に開発された、TeXなどの今までのシステムを覆しうる革新的で多機能な組版エンジンです。もちろん、学術論文に限らず、雑誌や書籍の組版にも適しています。
 
-このWebサイトは、[Typst GmbH](https://typst.app/legal/) の許諾を得て、非公式日本語コミュニティ「[Typst Japan Community](https://github.com/typst-jp/)」のボランティアたちが[公式ドキュメント](https://typst.app/docs/)を翻訳したものです。まだ翻訳途上ですので、翻訳されていない部分や誤訳などがたくさんあり、また情報が古くなる可能性もあるため、ご了承ください。最新の情報は[公式ドキュメント](https://typst.app/docs/)をご覧ください。ただし、本Webサイトには、公式ドキュメントにはない日本語の組版に特化した情報やコンテンツも掲載される予定です。
+このWebサイトは、[Typst GmbH](https://typst.app/legal/) の許諾を得て、非公式日本語コミュニティ「[Typst Japanese Community](https://github.com/typst-jp/)」のボランティアたちが[公式ドキュメント](https://typst.app/docs/)を翻訳したものです。まだ翻訳途上ですので、翻訳されていない部分や誤訳などがたくさんあり、また情報が古くなる可能性もあるため、ご了承ください。最新の情報は[公式ドキュメント](https://typst.app/docs/)をご覧ください。ただし、本Webサイトには、公式ドキュメントにはない日本語の組版に特化した情報やコンテンツも掲載される予定です。
 
 皆様がTypstをご利用になる上で、本サイトの情報が一助になれば幸いです。
 

--- a/website/src/components/ui/common/Footer.tsx
+++ b/website/src/components/ui/common/Footer.tsx
@@ -37,7 +37,7 @@ export const Footer = () => {
 							href={githubOrganizationUrl}
 							class="text-gray-600 hover:text-gray-800 transition-colors"
 						>
-							Typst Japan Community
+							Typst Japanese Community
 						</a>
 					</p>
 				</div>

--- a/website/src/components/ui/common/SiteNoticeBanner.tsx
+++ b/website/src/components/ui/common/SiteNoticeBanner.tsx
@@ -50,7 +50,7 @@ export const SiteNoticeBanner = () => {
 					</span>
 					<span class="block flex-1 pt-1 pb-2 leading-normal sm:inline sm:pt-0 sm:pb-0">
 						当サイトは、Typst GmbHの許諾を得て、日本語コミュニティ「
-						<a href={githubOrganizationUrl}>Typst Japan Community</a>」が
+						<a href={githubOrganizationUrl}>Typst Japanese Community</a>」が
 						<a href={typstOfficialDocsUrl}>
 							Typst v{version}の公式ドキュメント
 						</a>
@@ -65,7 +65,7 @@ export const SiteNoticeBanner = () => {
 						This site provides a Japanese translation of the{" "}
 						<a href={typstOfficialDocsUrl}>Typst v{version} documentation</a>{" "}
 						maintained by the "
-						<a href={githubOrganizationUrl}>Typst Japan Community</a>" with
+						<a href={githubOrganizationUrl}>Typst Japanese Community</a>" with
 						permission from Typst GmbH. We recommend using this alongside the{" "}
 						<a href={typstOfficialDocsUrl}>official documentation</a>. We
 						welcome contributions through Issues and Pull Requests on{" "}


### PR DESCRIPTION
cf. https://github.com/typst-jp/typst-jp.github.io/pull/188#discussion_r2138903460

## 変更点

- Webサイト内の「Typst Japan Community」を「Typst Japanese Community」に置換した

## 備考

- マージ前にOrganizationの名称も変更する
- Identificationとしての`jp`は変更しない