### PR TITLE
`docs/reference/model/list/`の訳抜けの修正

### DIFF
--- a/crates/typst-library/src/model/list.rs
+++ b/crates/typst-library/src/model/list.rs
@@ -16,7 +16,7 @@ use crate::text::TextElem;
 /// 各項目の先頭にマーカーを付け、
 /// 一連の項目を縦に並べて表示します。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// Normal list.
 /// - Text


### PR DESCRIPTION
[model/list/](https://typst-jp.github.io/docs/reference/model/list/)において、#122 での訳でセクション名である"Exmple"が訳抜けしてしまっていたため、「例」と訳しました。

【修正前】
<img width="733" height="343" alt="image" src="https://github.com/user-attachments/assets/8aad69e6-a3c8-4ca0-9f59-7c6f6abe26c5" />

【修正後】
<img width="688" height="333" alt="image" src="https://github.com/user-attachments/assets/0fa0a3da-c48b-4d58-bc1d-fab690504643" />
