### PR TITLE
`/docs/reference/text/lower`および`/docs/reference/text/upper`の翻訳

### DIFF
--- a/crates/typst-library/src/text/case.rs
+++ b/crates/typst-library/src/text/case.rs
@@ -1,9 +1,9 @@
 use crate::foundations::{cast, func, Cast, Content, Str};
 use crate::text::TextElem;
 
-/// Converts a string or content to lowercase.
+/// 文字列かコンテンツの小文字への変換。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// #lower("ABC") \
 /// #lower[*My Text*] \
@@ -11,7 +11,7 @@ use crate::text::TextElem;
 /// ```
 #[func(title = "Lowercase")]
 pub fn lower(
-    /// The text to convert to lowercase.
+    /// 小文字に変換するテキスト。
     text: Caseable,
 ) -> Caseable {
     case(text, Case::Lower)

--- a/crates/typst-library/src/text/case.rs
+++ b/crates/typst-library/src/text/case.rs
@@ -1,7 +1,7 @@
 use crate::foundations::{cast, func, Cast, Content, Str};
 use crate::text::TextElem;
 
-/// 文字列かコンテンツの小文字への変換。
+/// 文字列やコンテンツを小文字に変換。
 ///
 /// # 例
 /// ```example
@@ -17,7 +17,7 @@ pub fn lower(
     case(text, Case::Lower)
 }
 
-/// 文字列かコンテンツの大文字への変換。
+///  文字列やコンテンツを大文字に変換。
 ///
 /// # 例
 /// ```example

--- a/crates/typst-library/src/text/case.rs
+++ b/crates/typst-library/src/text/case.rs
@@ -17,9 +17,9 @@ pub fn lower(
     case(text, Case::Lower)
 }
 
-/// Converts a string or content to uppercase.
+/// 文字列かコンテンツの大文字への変換。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// #upper("abc") \
 /// #upper[*my text*] \
@@ -27,7 +27,7 @@ pub fn lower(
 /// ```
 #[func(title = "Uppercase")]
 pub fn upper(
-    /// The text to convert to uppercase.
+    /// 大文字に変換するテキスト。
     text: Caseable,
 ) -> Caseable {
     case(text, Case::Upper)

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -76,7 +76,7 @@
 	"/docs/reference/text/super/": "untranslated",
 	"/docs/reference/text/text/": "untranslated",
 	"/docs/reference/text/underline/": "translated",
-	"/docs/reference/text/upper/": "untranslated",
+	"/docs/reference/text/upper/": "translated",
 	"/docs/reference/math/": "translated",
 	"/docs/reference/math/accent/": "translated",
 	"/docs/reference/math/attach/": "translated",

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -66,7 +66,7 @@
 	"/docs/reference/text/highlight/": "translated",
 	"/docs/reference/text/linebreak/": "translated",
 	"/docs/reference/text/lorem/": "translated",
-	"/docs/reference/text/lower/": "untranslated",
+	"/docs/reference/text/lower/": "translated",
 	"/docs/reference/text/overline/": "translated",
 	"/docs/reference/text/raw/": "untranslated",
 	"/docs/reference/text/smallcaps/": "untranslated",


### PR DESCRIPTION
[text/lower](https://typst.app/docs/reference/text/lower)および[text/upper](https://typst.app/docs/reference/text/upper)の翻訳です。