### PR TITLE
`/docs/reference/model/outline`の翻訳

### DIFF
--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -420,7 +420,7 @@ impl OutlineEntry {
         ///
         /// デフォルトのshowルールでは`it.prefix()`ですが、自由にカスタマイズできます。
         prefix: Option<Content>,
-        /// 項目のフォーマットされた内部コンテンツ
+        /// 項目のフォーマットされた内部コンテンツ。
         ///
         /// デフォルトのshowルールでは`it.inner()`ですが、自由にカスタマイズできます。
         inner: Content,

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -24,14 +24,12 @@ use crate::math::EquationElem;
 use crate::model::{Destination, HeadingElem, NumberingPattern, ParElem, Refable};
 use crate::text::{LocalName, SpaceElem, TextElem};
 
-/// A table of contents, figures, or other elements.
+/// 目次や図表などのアウトライン。
 ///
-/// This function generates a list of all occurrences of an element in the
-/// document, up to a given [`depth`]($outline.depth). The element's numbering
-/// and page number will be displayed in the outline alongside its title or
-/// caption.
+/// この関数は、指定した[`depth`]($outline.depth)までに登場する要素を文書内から抽出し、その一覧（アウトライン）を生成します。
+/// 各要素には、その見出しやキャプションとともに、その要素の番号やページ番号がアウトライン形式で表示されます。
 ///
-/// # Example
+/// # 例
 /// ```example
 /// #set heading(numbering: "1.")
 /// #outline()
@@ -44,18 +42,14 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// #lorem(10)
 /// ```
 ///
-/// # Alternative outlines
-/// In its default configuration, this function generates a table of contents.
-/// By setting the `target` parameter, the outline can be used to generate a
-/// list of other kinds of elements than headings.
+/// # 見出し以外のアウトライン { #alternative-outlines }
+/// デフォルト設定では、この関数は目次（セクション見出しのアウトライン）を生成します。
+/// `target`パラメーターを設定することで、見出し以外の要素のアウトラインも生成できます。
 ///
-/// In the example below, we list all figures containing images by setting
-/// `target` to `{figure.where(kind: image)}`. Just the same, we could have set
-/// it to `{figure.where(kind: table)}` to generate a list of tables.
+/// 下の例では、`target`を`{figure.where(kind: image)}`に設定して、画像を含む図のみをアウトライン表示しています。
+/// 同様に`{figure.where(kind: table)}`と設定すれば、表のアウトラインを生成できます。
 ///
-/// We could also set it to just `figure`, without using a [`where`]($function.where)
-/// selector, but then the list would contain _all_ figures, be it ones
-/// containing images, tables, or other material.
+/// [`where`]($function.where)セレクターを使わずに`figure`のみの指定もできますが、その場合は画像や表、またその他の素材も含む _すべて_ の図表がアウトラインに表示されます。
 ///
 /// ```example
 /// #outline(
@@ -69,20 +63,15 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// )
 /// ```
 ///
-/// # Styling the outline
-/// At the most basic level, you can style the outline by setting properties on
-/// it and its entries. This way, you can customize the outline's
-/// [title]($outline.title), how outline entries are
-/// [indented]($outline.indent), and how the space between an entry's text and
-/// its page number should be [filled]($outline.entry.fill).
+/// # アウトラインのスタイル { #styling-the-outline }
+/// 基本的に、アウトライン本体やその項目に対してプロパティを設定することでスタイルを変更できます。
+/// これにより、アウトラインの[タイトル]($outline.title)、項目の[インデント]($outline.indent)、項目のテキストとページ番号の間の[空白の埋め方]($outline.entry.fill)などをカスタマイズできます。
 ///
-/// Richer customization is possible through configuration of the outline's
-/// [entries]($outline.entry). The outline generates one entry for each outlined
-/// element.
+/// アウトラインの[項目]($outline.entry)を設定を調整することで、より高度なカスタマイズも可能です。
+/// アウトラインは、対象となる各要素に対して1つの項目を生成します。
 ///
-/// ## Spacing the entries { #entry-spacing }
-/// Outline entries are [blocks]($block), so you can adjust the spacing between
-/// them with normal block-spacing rules:
+/// ## 項目同士の間隔調整 { #entry-spacing }
+/// アウトラインの各項目は[ブロック要素]($block)であるため、通常のブロック間隔設定を用いて、項目同士の間隔を調整できます。
 ///
 /// ```example
 /// #show outline.entry.where(
@@ -98,16 +87,13 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// == ACME Tools
 /// ```
 ///
-/// ## Building an outline entry from its parts { #building-an-entry }
-/// For full control, you can also write a transformational show rule on
-/// `outline.entry`. However, the logic for properly formatting and indenting
-/// outline entries is quite complex and the outline entry itself only contains
-/// two fields: The level and the outlined element.
+/// ## アウトライン項目の構築 { #building-an-entry }
+/// 項目の外観を完全に制御するために、`outline.entry`を変更するshowルールも書けます。
+/// ただし、アウトライン項目を適切に書式設定・インデントするための処理は非常に複雑であり、アウトライン項目自体が持つフィールドは「レベル」と「対象要素」の2つのみです。
 ///
-/// For this reason, various helper functions are provided. You can mix and
-/// match these to compose an entry from just the parts you like.
+/// そのため、必要な部分だけを組み合わせて項目を構築できるよう、さまざまな補助関数が提供されています。
 ///
-/// The default show rule for an outline entry looks like this[^1]:
+/// アウトライン項目に対する既定のshowルールは次のようになっています[^1]。:
 /// ```typ
 /// #show outline.entry: it => link(
 ///   it.element.location(),
@@ -115,21 +101,16 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// )
 /// ```
 ///
-/// - The [`indented`]($outline.entry.indented) function takes an optional
-///   prefix and inner content and automatically applies the proper indentation
-///   to it, such that different entries align nicely and long headings wrap
-///   properly.
+/// - [`indented`]($outline.entry.indented)関数は、任意のプレフィックスと内部コンテンツを受け取り、適切なインデントを自動的に適用します。
+///   これにより、異なる項目同士がきれいに揃い、長い見出しも正しく折り返されます。
 ///
-/// - The [`prefix`]($outline.entry.prefix) function formats the element's
-///   numbering (if any). It also appends a supplement for certain elements.
+/// - [`prefix`]($outline.entry.prefix)関数は、要素の番号（存在する場合）を整形します。
+///   また、特定の要素には補足語も付加します。
 ///
-/// - The [`inner`]($outline.entry.inner) function combines the element's
-///   [`body`]($outline.entry.body), the filler, and the
-///   [`page` number]($outline.entry.page).
+/// - [`inner`]($outline.entry.inner)関数は、要素の[`body`]($outline.entry.body)と[`page` number]($outline.entry.page)、およびそれらの間を埋めるフィラー（点線など）を組み合わせます。
 ///
-/// You can use these individual functions to format the outline entry in
-/// different ways. Let's say, you'd like to fully remove the filler and page
-/// numbers. To achieve this, you could write a show rule like this:
+/// これらの関数を個別に使うことで、アウトライン項目の書式を変更できます。
+/// たとえば、フィラーやページ番号を完全に削除したい場合は、次のようなshowルールを書くことができます。
 ///
 /// ```example
 /// #show outline.entry: it => link(
@@ -145,28 +126,23 @@ use crate::text::{LocalName, SpaceElem, TextElem};
 /// == History
 /// ```
 ///
-/// [^1]: The outline of equations is the exception to this rule as it does not
-///       have a body and thus does not use indented layout.
+/// [^1]: 数式のアウトラインはこのルールの例外で、本文を持たないためインデント付きのレイアウトは使用しません。
 #[elem(scope, keywords = ["Table of Contents", "toc"], Show, ShowSet, LocalName, Locatable)]
 pub struct OutlineElem {
-    /// The title of the outline.
+    /// アウトラインのタイトル。
     ///
-    /// - When set to `{auto}`, an appropriate title for the
-    ///   [text language]($text.lang) will be used.
-    /// - When set to `{none}`, the outline will not have a title.
-    /// - A custom title can be set by passing content.
+    /// - `{auto}`と設定すると[text language]($text.lang)に従ったタイトル名となります。
+    /// - `{none}`と設定すると、タイトルなしとなります。
+    /// - 独自のタイトルはコンテンツとして設定できます。
     ///
-    /// The outline's heading will not be numbered by default, but you can
-    /// force it to be with a show-set rule:
-    /// `{show outline: set heading(numbering: "1.")}`
+    /// アウトライン自体はデフォルトでは見出しとして番号付けされません。
+    /// 強制的に番号付けしたい場合は、`{show outline: set heading(numbering: "1.")}`のようにshow-setルールを使います。
     pub title: Smart<Option<Content>>,
 
-    /// The type of element to include in the outline.
+    /// アウトラインにする要素の種類。
     ///
-    /// To list figures containing a specific kind of element, like an image or
-    /// a table, you can specify the desired kind in a [`where`]($function.where)
-    /// selector. See the section on [alternative outlines]($outline/#alternative-outlines)
-    /// for more details.
+    /// 特定の種類の要素（画像や表など）のみを含む図表をアウトライン表示したい場合は、[`where`]($function.where)セレクターで目的の種類を指定できます。
+    /// 詳細は[見出し以外のアウトライン]($outline/#alternative-outlines)のセクションをご参照ください。
     ///
     /// ```example
     /// #outline(
@@ -187,8 +163,8 @@ pub struct OutlineElem {
     #[borrowed]
     pub target: LocatableSelector,
 
-    /// The maximum level up to which elements are included in the outline. When
-    /// this argument is `{none}`, all elements are included.
+    /// アウトラインに含める要素の最大レベル。
+    /// この引数が`{none}`の場合は、すべての要素が含まれます。
     ///
     /// ```example
     /// #set heading(numbering: "1.")
@@ -205,24 +181,17 @@ pub struct OutlineElem {
     /// ```
     pub depth: Option<NonZeroUsize>,
 
-    /// How to indent the outline's entries.
+    /// どのようにアウトライン項目をインデントするか。
     ///
-    /// - `{auto}`: Indents the numbering/prefix of a nested entry with the
-    ///   title of its parent entry. If the entries are not numbered (e.g., via
-    ///   [heading numbering]($heading.numbering)), this instead simply inserts
-    ///   a fixed amount of `{1.2em}` indent per level.
+    /// - `{auto}`: 入れ子になった項目の番号やプレフィックスを、親項目のタイトル位置に揃えてインデントします。
+    ///   たとえば[見出しの番号付け]($heading.numbering)で項目が番号付きとしない設定をしている場合には、レベルに応じて単純に固定幅`{1.2em}`のインデントを追加します。
     ///
-    /// - [Relative length]($relative): Indents the entry by the specified
-    ///   length per nesting level. Specifying `{2em}`, for instance, would
-    ///   indent top-level headings by `{0em}` (not nested), second level
-    ///   headings by `{2em}` (nested once), third-level headings by `{4em}`
-    ///   (nested twice) and so on.
+    /// - [相対長さ]($relative): ネストレベルごとに指定した長さ分だけインデントします。
+    ///   具体例として`{2em}`と指定すると、最上位レベル（ネストなし）のインデントは`{0em}`、第2レベル（1段階のネスト）のインデントは`{2em}`、第3レベル（2段階のネスト）は`{4em}`といった具合に設定されます。
     ///
-    /// - [Function]($function): You can further customize this setting with a
-    ///   function. That function receives the nesting level as a parameter
-    ///   (starting at 0 for top-level headings/elements) and should return a
-    ///   (relative) length. For example, `{n => n * 2em}` would be equivalent
-    ///   to just specifying `{2em}`.
+    /// - [関数]($function): 関数を使ってさらに細かくカスタマイズできます。
+    ///   関数はネストレベルが引数として渡され（最上位要素は0）、相対長さを返します。
+    ///   たとえば`{n => n * 2em}`とすれば単に`{2em}`を指定した場合と同じ結果となります。
     ///
     /// ```example
     /// #set heading(numbering: "1.a.")
@@ -363,35 +332,29 @@ pub trait Outlinable: Refable {
     fn body(&self) -> Content;
 }
 
-/// Represents an entry line in an outline.
+/// アウトライン内の項目。
 ///
-/// With show-set and show rules on outline entries, you can richly customize
-/// the outline's appearance. See the
-/// [section on styling the outline]($outline/#styling-the-outline) for details.
+/// show-setルールやshowルールをアウトライン項目に適用することで、アウトラインの見た目を柔軟にカスタマイズできます。
+/// 詳細は[アウトラインのスタイルのセクション]($outline/#styling-the-outline)をご参照ください。
 #[elem(scope, name = "entry", title = "Outline Entry", Show)]
 pub struct OutlineEntry {
-    /// The nesting level of this outline entry. Starts at `{1}` for top-level
-    /// entries.
+    /// アウトライン項目のネストレベル。
+    /// 最上位のネストレベルは`{1}`から始まります。
     #[required]
     pub level: NonZeroUsize,
 
-    /// The element this entry refers to. Its location will be available
-    /// through the [`location`]($content.location) method on the content
-    /// and can be [linked]($link) to.
+    /// この項目が参照している要素。
+    /// 要素の位置は、コンテンツの[`location`]($content.location)メソッドで取得でき、これに対する[linked]($link)も使用可能です。
     #[required]
     pub element: Content,
 
-    /// Content to fill the space between the title and the page number. Can be
-    /// set to `{none}` to disable filling.
+    /// タイトルとページ番号の間を埋めるためのコンテンツ。
+    /// コンテンツで埋めない場合には`{none}`を指定できます。
     ///
-    /// The `fill` will be placed into a fractionally sized box that spans the
-    /// space between the entry's body and the page number. When using show
-    /// rules to override outline entries, it is thus recommended to wrap the
-    /// fill in a [`box`] with fractional width, i.e.
-    /// `{box(width: 1fr, it.fill}`.
+    /// `fill`は、項目の本文とページ番号の間をまたぐ可変幅のボックスに配置されます。
+    /// そのため、アウトライン項目をshowルールで上書きする場合は、fillを`{box(width: 1fr, it.fill}`のように可変長の[`box`]でラップすることが推奨されます。
     ///
-    /// When using [`repeat`], the [`gap`]($repeat.gap) property can be useful
-    /// to tweak the visual weight of the fill.
+    /// [`repeat`]を使う場合には、[`gap`]($repeat.gap)プロパティを調整すると、fillの見た目を微調整できます。
     ///
     /// ```example
     /// #set outline.entry(fill: line(length: 100%))
@@ -440,36 +403,28 @@ impl Show for Packed<OutlineEntry> {
 
 #[scope]
 impl OutlineEntry {
-    /// A helper function for producing an indented entry layout: Lays out a
-    /// prefix and the rest of the entry in an indent-aware way.
+    /// インデント付きの項目レイアウトを作成するための補助関数。
+    /// プレフィックスと項目本文を、インデントを考慮して配置します。
     ///
-    /// If the parent outline's [`indent`]($outline.indent) is `{auto}`, the
-    /// inner content of all entries at level `N` is aligned with the prefix of
-    /// all entries at level `N + 1`, leaving at least `gap` space between the
-    /// prefix and inner parts. Furthermore, the `inner` contents of all entries
-    /// at the same level are aligned.
+    /// 親アウトラインの[`indent`]($outline.indent)が`{auto}`の場合、レベル`N`の項目の内部（inner）コンテンツは、レベル`N + 1`の項目のプレフィックスに揃えられ、プレフィックスと内部コンテンツの間には最低でも`gap`分のスペースが空けられます。
+    /// さらに、同じレベルのすべての項目の`inner`コンテンツも整列されます。
     ///
-    /// If the outline's indent is a fixed value or a function, the prefixes are
-    /// indented, but the inner contents are simply inset from the prefix by the
-    /// specified `gap`, rather than aligning outline-wide.
+    /// アウトラインのインデントが固定値または関数に設定されている場合、プレフィックスはインデントされますが、内部コンテンツはアウトライン全体で整列されるのではなく、指定された`gap`分だけプレフィックスからオフセットされます。
     #[func(contextual)]
     pub fn indented(
         &self,
         engine: &mut Engine,
         context: Tracked<Context>,
         span: Span,
-        /// The `prefix` is aligned with the `inner` content of entries that
-        /// have level one less.
+        /// `prefix`は、レベルが1段低い項目の`inner`コンテンツと整列されます。
         ///
-        /// In the default show rule, this is just `it.prefix()`, but it can be
-        /// freely customized.
+        /// デフォルトのshowルールでは`it.prefix()`ですが、自由にカスタマイズできます。
         prefix: Option<Content>,
-        /// The formatted inner content of the entry.
+        /// 項目のフォーマットされた内部コンテンツ
         ///
-        /// In the default show rule, this is just `it.inner()`, but it can be
-        /// freely customized.
+        /// デフォルトのshowルールでは`it.inner()`ですが、自由にカスタマイズできます。
         inner: Content,
-        /// The gap between the prefix and the inner content.
+        /// プレフィックスと内部コンテンツの間の間隔です。
         #[named]
         #[default(Em::new(0.5).into())]
         gap: Length,
@@ -541,11 +496,10 @@ impl OutlineEntry {
             .spanned(span))
     }
 
-    /// Formats the element's numbering (if any).
+    /// 要素の番号付け（存在する場合）の出力形式。
     ///
-    /// This also appends the element's supplement in case of figures or
-    /// equations. For instance, it would output `1.1` for a heading, but
-    /// `Figure 1` for a figure, as is usual for outlines.
+    /// また、図や数式の場合は、通常のアウトラインと同様に要素の補足語も追加します。
+    /// たとえば、見出しであれば`1.1`と出力されますが、図であれば`Figure 1`と出力されます。
     #[func(contextual)]
     pub fn prefix(
         &self,
@@ -562,9 +516,9 @@ impl OutlineEntry {
         Ok(Some(outlinable.prefix(numbers)))
     }
 
-    /// Creates the default inner content of the entry.
+    /// 項目の規定の内部コンテンツを生成。
     ///
-    /// This includes the body, the fill, and page number.
+    /// これには、本文とフィラー、ページ番号が含まれます。
     #[func(contextual)]
     pub fn inner(
         &self,
@@ -621,17 +575,15 @@ impl OutlineEntry {
         Ok(Content::sequence(seq))
     }
 
-    /// The content which is displayed in place of the referred element at its
-    /// entry in the outline. For a heading, this is its
-    /// [`body`]($heading.body); for a figure a caption and for equations, it is
-    /// empty.
+    /// アウトライン内で参照される要素の代わりに表示される内容。
+    /// 見出しの場合は[`body`]($heading.body)、図表の場合はキャプション、数式の場合は空欄となります。
     #[func]
     pub fn body(&self) -> StrResult<Content> {
         Ok(self.outlinable()?.body())
     }
 
-    /// The page number of this entry's element, formatted with the numbering
-    /// set for the referenced page.
+    /// 要素の項目のページ番号。
+    /// これは参照されるページに対する番号付け設定の書式で出力されます。
     #[func(contextual)]
     pub fn page(
         &self,

--- a/crates/typst-library/src/model/outline.rs
+++ b/crates/typst-library/src/model/outline.rs
@@ -416,7 +416,7 @@ impl OutlineEntry {
         engine: &mut Engine,
         context: Tracked<Context>,
         span: Span,
-        /// `prefix`は、レベルが1段低い項目の`inner`コンテンツと整列されます。
+        /// `prefix`は、レベルが1段低い項目の`inner`コンテンツと揃うように配置されます。
         ///
         /// デフォルトのshowルールでは`it.prefix()`ですが、自由にカスタマイズできます。
         prefix: Option<Content>,

--- a/website/translation-status.json
+++ b/website/translation-status.json
@@ -54,7 +54,7 @@
 	"/docs/reference/model/link/": "translated",
 	"/docs/reference/model/enum/": "translated",
 	"/docs/reference/model/numbering/": "translated",
-	"/docs/reference/model/outline/": "untranslated",
+	"/docs/reference/model/outline/": "translated",
 	"/docs/reference/model/par/": "translated",
 	"/docs/reference/model/parbreak/": "translated",
 	"/docs/reference/model/quote/": "translated",


### PR DESCRIPTION
- outline →訳出として「一覧」「概要」なども候補にありましたが、誤解が生じそうな場所もあったため、「アウトライン」に統一しました。
- inner contents →「内部コンテンツ」としました。コードの`inner`がそのまま置かれている場所と混ざってしまいましたが、初出で「内部（inner）コンテンツ」と表記することで対応しているつもりです。
- entry →「項目」としました。[footnoteのentry](https://typst-jp.github.io/docs/reference/model/footnote/#definitions-entry)と訳を揃えております。